### PR TITLE
Update add order status form 

### DIFF
--- a/controllers/admin/AdminStatusesController.php
+++ b/controllers/admin/AdminStatusesController.php
@@ -322,7 +322,10 @@ class AdminStatusesControllerCore extends AdminController
 
     public function renderForm()
     {
-        if (Tools::isSubmit('updateorder_state') || Tools::isSubmit('addorder_state')) {
+        if (Tools::isSubmit('updateorder_state')
+            || Tools::isSubmit('addorder_state')
+            || Tools::isSubmit('submitAddorder_state')
+        ) {
             $this->fields_form = array(
                 'tinymce' => true,
                 'legend' => array(


### PR DESCRIPTION
Order status form redirect to blank page when submit with incorrect status name


![Screenshot (1)](https://user-images.githubusercontent.com/55269017/96256188-d02d1c00-0fd5-11eb-9c73-5fa1ad7affc9.png)
