### PR TITLE
Updated order retrun status form

### DIFF
--- a/controllers/admin/AdminStatusesController.php
+++ b/controllers/admin/AdminStatusesController.php
@@ -56,6 +56,12 @@ class AdminStatusesControllerCore extends AdminController
         if (Tools::isSubmit('updateorder_return_state')) {
             $this->display = 'edit';
         }
+        if (Tools::isSubmit('submitAddorder_return_state')) {
+            $this->display = 'add';
+            if(Tools::getValue('id_order_return_state')) {
+                $this->display = 'edit';
+            }
+        }
 
         return parent::init();
     }
@@ -478,7 +484,10 @@ class AdminStatusesControllerCore extends AdminController
                 )
             );
             return $this->renderOrderStatusForm();
-        } elseif (Tools::isSubmit('updateorder_return_state') || Tools::isSubmit('addorder_return_state')) {
+        } elseif (Tools::isSubmit('updateorder_return_state')
+            || Tools::isSubmit('addorder_return_state')
+            || Tools::isSubmit('submitAddorder_return_state')
+        ) {
             return $this->renderOrderReturnsForm();
         } else {
             return parent::renderForm();


### PR DESCRIPTION
Issue: Redirecting to the list page when saving order refund status without entering "status name"

![Screenshot (2)](https://user-images.githubusercontent.com/55269017/96256333-14b8b780-0fd6-11eb-92fa-58a007cbf635.png)
