### PR TITLE
fix new room issue for employee

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -80,9 +80,9 @@ class AdminProductsControllerCore extends AdminController
 
         // START send access query information to the admin controller
         $this->access_select = ' SELECT a.`id_product` FROM '._DB_PREFIX_.'product a';
-        $this->access_join = ' INNER JOIN '._DB_PREFIX_.'htl_room_type hrt ON (hrt.id_product = a.id_product)';
+        $this->access_join = ' LEFT JOIN '._DB_PREFIX_.'htl_room_type hrt ON (hrt.id_product = a.id_product)';
         if ($acsHtls = HotelBranchInformation::getProfileAccessedHotels($this->context->employee->id_profile, 1, 1)) {
-            $this->access_where = ' WHERE hrt.id_hotel IN ('.implode(',', $acsHtls).')';
+            $this->access_where = ' WHERE (hrt.id_hotel IN ('.implode(',', $acsHtls).') OR hrt.id_hotel IS NULL)';
         }
 
         parent::__construct();


### PR DESCRIPTION
Fixes #159 

Now employees having room type controller access can view rooms of their hotel as well as rooms that are not assigned to any hotel.
So now new room created will be accessible for the employee to edit.