### PR TITLE
updated helper list header

### DIFF
--- a/admin/themes/default/template/helpers/list/list_header.tpl
+++ b/admin/themes/default/template/helpers/list/list_header.tpl
@@ -25,7 +25,7 @@
 {if $ajax}
 	<script type="text/javascript">
 		$(function () {
-			$(".ajax_table_link").click(function () {
+			$("#form-{$list_id} .ajax_table_link").click(function () {
 				var link = $(this);
 				$.post($(this).attr('href'), function (data) {
 					if (data.success == 1) {


### PR DESCRIPTION
when adding multiple list on same page the script for the status change is also added multiple times, calling the status change multiple times.
Now the script is limited to the list_id of the form (i.e List table).
fixes #164 