### PR TITLE
Entering wrong discount while Group creation, page redirects to list page

### DIFF
--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -451,6 +451,7 @@ class AdminGroupsControllerCore extends AdminController
     {
         if (!$this->validateDiscount(Tools::getValue('reduction'))) {
             $this->errors[] = Tools::displayError('The discount value is incorrect (must be a percentage).');
+            $this->display = 'edit';
         } else {
             $this->updateCategoryReduction();
             $object = parent::processSave();


### PR DESCRIPTION
When we enter the wrong discount percentage during the group creation, the page redirects to the list page instead of the edit page, and the 'Add new group' button gets hidden.