### PR TITLE
Guest is unable to submit Refund Request again after entering invalid Refund Reason once

### DIFF
--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -204,6 +204,8 @@ class OrderDetailControllerCore extends FrontController
                 $hasError = 0;
                 if (!$refundReason = Tools::getValue('cancellation_reason')) {
                     $hasError = 1;
+                } elseif (!Validate::isCleanHtml($refundReason)) {
+                    $hasError = 1;
                 }
                 if ($bookingRefunds = Tools::getValue('bookings_to_refund')) {
                     if (!count($bookingRefunds = Tools::jsonDecode($bookingRefunds, true))) {

--- a/themes/hotel-reservation-theme/js/history.js
+++ b/themes/hotel-reservation-theme/js/history.js
@@ -236,12 +236,14 @@ $(document).ready(function(){
 
 							showOrder(1, $("input[name=id_order]").val(), historyUrl)
 			        	} else {
-			        		showErrorMessage(refund_request_sending_error);
+							showErrorMessage(refund_request_sending_error);
+							$('#submit_refund_reason').attr('disabled', false);
 						}
 						$(".loading_overlay").hide();
 			        },
 			        error: function(XMLHttpRequest, textStatus, errorThrown) {
 						showErrorMessage(textStatus);
+						$('#submit_refund_reason').attr('disabled', false);
 						$(".loading_overlay").hide();
 			        }
 		    	});


### PR DESCRIPTION
When a guest enters an invalid order refund reason on the order detail page, after clicking the submit button it becomes disabled and the guest can not submit the refund request again.