### PR TITLE
Prevent deleting profile which is used by at least one employee

### DIFF
--- a/classes/Profile.php
+++ b/classes/Profile.php
@@ -94,12 +94,17 @@ class ProfileCore extends ObjectModel
 
     public function delete()
     {
-        if (parent::delete()) {
-            return (
-                Db::getInstance()->execute('DELETE FROM `'._DB_PREFIX_.'access` WHERE `id_profile` = '.(int)$this->id)
-                && Db::getInstance()->execute('DELETE FROM `'._DB_PREFIX_.'module_access` WHERE `id_profile` = '.(int)$this->id)
-            );
+        // check if any employee exists of this deleting profile before delete
+        $profileEmployees = Employee::getEmployeesByProfile($this->id);
+        if (empty($profileEmployees)) {
+            if (parent::delete()) {
+                return (
+                    Db::getInstance()->execute('DELETE FROM `'._DB_PREFIX_.'access` WHERE `id_profile` = '.(int)$this->id)
+                    && Db::getInstance()->execute('DELETE FROM `'._DB_PREFIX_.'module_access` WHERE `id_profile` = '.(int)$this->id)
+                );
+            }
         }
+
         return false;
     }
 

--- a/controllers/admin/AdminProfilesController.php
+++ b/controllers/admin/AdminProfilesController.php
@@ -115,4 +115,40 @@ class AdminProfilesControllerCore extends AdminController
 
         parent::initPageHeaderToolbar();
     }
+
+    public function processDelete()
+    {
+        if (Validate::isLoadedObject($object = $this->loadObject())) {
+            // check if any employee exists of this deleting profile before delete
+            $profileEmployees = Employee::getEmployeesByProfile($object->id);
+            if (empty($profileEmployees)) {
+                return parent::processDelete();
+            } else {
+                $this->errors[] = $this->l('Failed to delete profile, because it is assigned to at least one employee.');
+            }
+        } else {
+            $this->errors[] = $this->l('An error occurred while deleting the profile.').' '.$this->l('(cannot load object)');
+        }
+
+        return false;
+    }
+
+    protected function processBulkDelete()
+    {
+        if (is_array($this->boxes) && !empty($this->boxes)) {
+            foreach ($this->boxes as $idProfile) {
+                // check if any employee exists of this deleting profile before delete
+                $profileEmployees = Employee::getEmployeesByProfile($idProfile);
+                if (!empty($profileEmployees)) {
+                    $this->errors[] = $this->l('Failed to delete profile with id').' - #'.$idProfile.' '.$this->l('because it is assigned to at least one employee. Please remove it from selection.');
+                }
+            }
+        }
+
+        if (empty($this->errors)) {
+            return parent::processBulkDelete();
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
Admin can delete the profiles regardless employees are assigned to that profiles or not. and then issues have occurred in the back-office when logged in employee's profile is not found.
So we have to Prevent deleting profile which is used by at least one employee 