### PR TITLE
Errors on the search result page: If new group is created and only this group is assigned to the customer

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1367,6 +1367,45 @@ class CategoryCore extends ObjectModel
 		VALUES ('.(int)Context::getContext()->shop->getCategory().', '.(int)$id_group.')');
     }
 
+    /**
+     * Assign one (ore more) group to all categories
+     * @param int|array $id_group_list group id or list of group ids
+     * @param array $exception list of id Categories to ignore
+    */
+    public static function assignGroupToAllCategories($idGroupList, $exception = null)
+    {
+
+        if (!is_array($idGroupList)) {
+            $idGroupList = array($idGroupList);
+        }
+
+        Db::getInstance()->execute(
+            'DELETE FROM `'._DB_PREFIX_.'category_group`
+            WHERE `id_group` IN ('.join(',', $idGroupList).')'
+        );
+
+        $categoryList = Db::getInstance()->executeS(
+            'SELECT id_category FROM `'._DB_PREFIX_.'category` '.
+            (is_array($exception) ? ' WHERE  id_category NOT IN ('.join(',', $exception).')' : '')
+        );
+
+        if ($categoryList) {
+            $data = array();
+            foreach ($categoryList as $category) {
+                foreach ($idGroupList as $idGroup) {
+                    $data[] = array(
+                        'id_category' => $category['id_category'],
+                        'id_group' => $idGroup,
+                    );
+                }
+            }
+
+            return Db::getInstance()->insert('category_group', $data, false, false);
+        }
+
+        return true;
+    }
+
     public function updatePosition($way, $position)
     {
         if (!$res = Db::getInstance()->executeS('

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -163,7 +163,7 @@ class GroupCore extends ObjectModel
     {
         Configuration::updateGlobalValue('PS_GROUP_FEATURE_ACTIVE', '1');
         if (parent::add($autodate, $null_values)) {
-            Category::setNewGroupForHome((int)$this->id);
+            Category::assignGroupToAllCategories((int)$this->id);
             Carrier::assignGroupToAllCarriers((int)$this->id);
             return true;
         }


### PR DESCRIPTION
If a new group is created and only this group is assigned to the customer and as default group then no results are displayed in the search result page and also errors are displayed on the search result page.

**Problem** : This issue is occurring because the newly created group has no access to any category of hotels and locations. So it is the group access issue.
**Solution** : If a new group is added, It will be automatically added in the Group Access of all categories. So that all categories(locations/hotels) can be accessed by the customers connected to that added group

Fixed #220 