### PR TITLE
Errors on cart rule page when add room type, which is not assigned to hotel, selected in room type condition 

### DIFF
--- a/modules/hotelreservationsystem/classes/HotelBranchInformation.php
+++ b/modules/hotelreservationsystem/classes/HotelBranchInformation.php
@@ -277,6 +277,12 @@ class HotelBranchInformation extends ObjectModel
                                     unset($dataArray[$key]);
                                 }
                             }
+                        } else {
+                            if ($addAccessKey) {
+                                $dataArray[$key]['htl_access'] = 0;
+                            } else {
+                                unset($dataArray[$key]);
+                            }
                         }
                     } elseif (isset($row['id_product'])) {
                         $objRoomType = new HotelRoomType();
@@ -290,6 +296,12 @@ class HotelBranchInformation extends ObjectModel
                                 if (!in_array($roomTypeInfo['id_hotel'], $hotels)) {
                                     unset($dataArray[$key]);
                                 }
+                            }
+                        } else {
+                            if ($addAccessKey) {
+                                $dataArray[$key]['htl_access'] = 0;
+                            } else {
+                                unset($dataArray[$key]);
                             }
                         }
                     }


### PR DESCRIPTION
If you assign room type condition on that cart rule, Errors of hotel access are displayed in the edit cart rule page when adding a room type, which is not assigned to the hotel from the Room types page, selected in room type condition.