### PR TITLE
Added auto_generated column in address table to track address creation source

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -98,6 +98,9 @@ class AddressCore extends ObjectModel
     /** @var bool True if address has been deleted (staying in database as deleted) */
     public $deleted = 0;
 
+    /** @var bool True if address has been created automatically (by system) */
+    public $auto_generated;
+
     protected static $_idZones = array();
     protected static $_idCountries = array();
 
@@ -128,6 +131,7 @@ class AddressCore extends ObjectModel
             'phone_mobile' =>        array('type' => self::TYPE_STRING, 'validate' => 'isPhoneNumber', 'size' => 32),
             'dni' =>                array('type' => self::TYPE_STRING, 'validate' => 'isDniLite', 'size' => 16),
             'deleted' =>            array('type' => self::TYPE_BOOL, 'validate' => 'isBool', 'copy_post' => false),
+            'auto_generated' =>            array('type' => self::TYPE_BOOL, 'validate' => 'isBool'),
             'date_add' =>            array('type' => self::TYPE_DATE, 'validate' => 'isDate', 'copy_post' => false),
             'date_upd' =>            array('type' => self::TYPE_DATE, 'validate' => 'isDate', 'copy_post' => false),
         ),

--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -460,6 +460,7 @@ class AuthControllerCore extends FrontController
                             $_POST['alias'] = 'My address';
                             $_POST['id_country'] = $objHotel->country_id;
                             $_POST['id_state'] = $objHotel->state_id;
+                            $_POST['auto_generated'] = true;
                             // if form is shorter then address name will be customer name
                             $lastnameAddress = $_POST['lastname'];
                             $firstnameAddress = $_POST['firstname'];

--- a/install/data/db_structure.sql
+++ b/install/data/db_structure.sql
@@ -42,6 +42,7 @@ CREATE TABLE `PREFIX_address` (
   `date_upd` datetime NOT NULL,
   `active` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `deleted` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `auto_generated` tinyint(1) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_address`),
   KEY `address_customer` (`id_customer`),
   KEY `id_country` (`id_country`),


### PR DESCRIPTION
Added auto_generated column in address table for tracking address creation. 
To check if the address is created by the customer or generated by the system

If the address is created automatically during checkout, then the value for "auto_generated" will be 1 else 0