### PR TITLE
Added "feature_price_diff" in "dataforfrontsearch" function response

### DIFF
--- a/controllers/front/CategoryController.php
+++ b/controllers/front/CategoryController.php
@@ -150,7 +150,6 @@ class CategoryControllerCore extends FrontController
 
             $obj_booking_dtl = new HotelBookingDetail();
             $booking_data = $obj_booking_dtl->DataForFrontSearch($date_from, $date_to, $id_hotel, 0, 0, 0, 0, -1, 0, 0, $id_cart, $id_guest);
-            // ddd($booking_data);
 
             $feat_img_dir = _PS_IMG_.'rf/';
             $ratting_img = _MODULE_DIR_.'hotelreservationsystem/views/img/Slices/icons-sprite.png';
@@ -173,14 +172,6 @@ class CategoryControllerCore extends FrontController
             }
             /*End*/
 
-            if (isset($booking_data['rm_data']) && $booking_data['rm_data']) {
-                $useTax = HotelBookingDetail::useTax();
-                foreach ($booking_data['rm_data'] as $key => $roomType) {
-                    $feature_price = HotelRoomTypeFeaturePricing::getRoomTypeFeaturePricesPerDay($roomType['id_product'], $date_from, $date_to, $useTax);
-                    $booking_data['rm_data'][$key]['feature_price'] = $feature_price;
-                    $booking_data['rm_data'][$key]['feature_price_diff'] = (float)($roomType['price_without_reduction']-$feature_price);
-                }
-            }
             $this->context->smarty->assign(array(
                 'warning_num' => $warning_num,
                 'num_days' => $num_days,
@@ -275,16 +266,8 @@ class CategoryControllerCore extends FrontController
 
             $obj_booking_dtl = new HotelBookingDetail();
             $booking_data = $obj_booking_dtl->DataForFrontSearch($date_from, $date_to, $id_hotel, 0, 0, $adult, $child, $ratting, $amenities, $price, $id_cart, $id_guest);
-            if (isset($booking_data['rm_data']) && $booking_data['rm_data']) {
-                $useTax = HotelBookingDetail::useTax();
-                foreach ($booking_data['rm_data'] as $key => $roomType) {
-                    $feature_price = HotelRoomTypeFeaturePricing::getRoomTypeFeaturePricesPerDay($roomType['id_product'], $date_from, $date_to, $useTax);
-                    $booking_data['rm_data'][$key]['feature_price'] = $feature_price;
-                    $booking_data['rm_data'][$key]['feature_price_diff'] = (float)($roomType['price_without_reduction']-$feature_price);
-                }
-                // reset array keys from 0
-                $booking_data['rm_data'] = array_values($booking_data['rm_data']);
-            }
+            // reset array keys from 0
+            $booking_data['rm_data'] = array_values($booking_data['rm_data']);
             if ($sort_by && $sort_value) {
                 $indi_arr = array();
 

--- a/modules/hotelreservationsystem/classes/HotelBookingDetail.php
+++ b/modules/hotelreservationsystem/classes/HotelBookingDetail.php
@@ -897,6 +897,7 @@ class HotelBookingDetail extends ObjectModel
                                     $booking_data['rm_data'][$key]['price'] = $prod_price;
                                     $booking_data['rm_data'][$key]['price_without_reduction'] = $productPriceWithoutReduction;
                                     $booking_data['rm_data'][$key]['feature_price'] = $productFeaturePrice;
+                                    $booking_data['rm_data'][$key]['feature_price_diff'] = $productPriceWithoutReduction - $productFeaturePrice;
 
                                     // if ($room_left <= (int)Configuration::get('WK_ROOM_LEFT_WARNING_NUMBER'))
                                     $booking_data['rm_data'][$key]['room_left'] = $room_left;


### PR DESCRIPTION
Added `feature_price_diff` in `dataForFrontSearch` function.
Now `dataForFrontSearch` response contains `feature_price_diff` so no need to calculate it individually.