### PR TITLE
In _DB_PREFIX__orders table column advance_paid_amount value is wrong

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -355,7 +355,7 @@ abstract class PaymentModuleCore extends Module
 
                     // advance payment information
                     $order->is_advance_payment = $this->context->cart->is_advance_payment;
-                    $order->advance_paid_amount = $cart_total_paid;
+                    $order->advance_paid_amount = (float)Tools::ps_round((float)$this->context->cart->getOrderTotal(true, Cart::ADVANCE_PAYMENT, $order->product_list, $id_carrier), _PS_PRICE_COMPUTE_PRECISION_);
 
                     // Creating order
                     $result = $order->add();

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -355,7 +355,11 @@ abstract class PaymentModuleCore extends Module
 
                     // advance payment information
                     $order->is_advance_payment = $this->context->cart->is_advance_payment;
-                    $order->advance_paid_amount = (float)Tools::ps_round((float)$this->context->cart->getOrderTotal(true, Cart::ADVANCE_PAYMENT, $order->product_list, $id_carrier), _PS_PRICE_COMPUTE_PRECISION_);
+                    if ($order->is_advance_payment) {
+                        $order->advance_paid_amount = (float)Tools::ps_round((float)$this->context->cart->getOrderTotal(true, Cart::ADVANCE_PAYMENT, $order->product_list, $id_carrier), _PS_PRICE_COMPUTE_PRECISION_);
+                    } else {
+                        $order->advance_paid_amount = (float)Tools::ps_round((float)$this->context->cart->getOrderTotal(true, Cart::BOTH, $order->product_list, $id_carrier), _PS_PRICE_COMPUTE_PRECISION_);
+                    }
 
                     // Creating order
                     $result = $order->add();


### PR DESCRIPTION
When two rooms from different hotels are added in the cart. both rooms have advance payment enabled.
After order creation, cart's total advance payment amount is saved in both the order's advance_paid_amount columns.
no order wise advance payment entries.
