### PR TITLE
Resolved fatal error while generating class index file

### DIFF
--- a/classes/PrestaShopAutoload.php
+++ b/classes/PrestaShopAutoload.php
@@ -165,7 +165,7 @@ class PrestaShopAutoload
         }
         // $filename_tmp couldn't be written. $filename should be there anyway (even if outdated), no need to die.
         else {
-            Tools::error_log('Cannot write temporary file '.$filename_tmp);
+            error_log(print_r('Cannot write temporary file '.$filename_tmp, true));
         }
         $this->index = $classes;
     }


### PR DESCRIPTION
When there are not sufficient permissions while generating class_index file, Tools class function is called which is not included till that time in autoload.
Resolved by directly logging error in autoload class