### PR TITLE
Resolve jQZoom issue on room type detail page

### DIFF
--- a/install/data/xml/image_type.xml
+++ b/install/data/xml/image_type.xml
@@ -16,7 +16,7 @@
     <image_type id="small_default" name="small_default" width="98" height="98" products="1" categories="0" manufacturers="1" suppliers="1" scenes="0" stores="0"/>
     <image_type id="medium_default" name="medium_default" width="125" height="125" products="1" categories="1" manufacturers="1" suppliers="1" scenes="0" stores="1"/>
     <image_type id="home_default" name="home_default" width="250" height="250" products="1" categories="0" manufacturers="0" suppliers="0" scenes="0" stores="0"/>
-    <image_type id="large_default" name="large_default" width="458" height="458" products="1" categories="0" manufacturers="1" suppliers="1" scenes="0" stores="0"/>
+    <image_type id="large_default" name="large_default" width="640" height="640" products="1" categories="0" manufacturers="1" suppliers="1" scenes="0" stores="0"/>
     <image_type id="thickbox_default" name="thickbox_default" width="800" height="800" products="1" categories="0" manufacturers="0" suppliers="0" scenes="0" stores="0"/>
     <image_type id="category_default" name="category_default" width="870" height="217" products="0" categories="1" manufacturers="0" suppliers="0" scenes="0" stores="0"/>
     <image_type id="scene_default" name="scene_default" width="870" height="270" products="0" categories="0" manufacturers="0" suppliers="0" scenes="1" stores="0"/>

--- a/themes/hotel-reservation-theme/css/product.css
+++ b/themes/hotel-reservation-theme/css/product.css
@@ -1441,21 +1441,7 @@ Quick View Styles
 	margin-bottom: 15px;
 	text-transform: uppercase;}
 
-/* fancybox accordian css */
-/* #rooms_extra_demands .accordion, #rooms_extra_demands .accordion * {
-	-webkit-box-sizing:border-box;
-	-moz-box-sizing:border-box;
-	box-sizing:border-box;}
-#rooms_extra_demands .accordion {
-	overflow:hidden;
-	border-bottom: 1px solid #CCCCCC;}
-#rooms_extra_demands .accordion-section-title {
-	width:100%;
-	display:inline-block;
-	transition:all linear 0.15s;
-	color:#252525 !important;
-	text-decoration:none !important;}
-#rooms_extra_demands .accordion-section-content {
-	display:none;
-	border-top: 1px solid #eee;
-	padding-top: 15px;} */
+/* jqZoom overrides */
+.zoomWrapperImage img {
+  height: initial !important;
+}


### PR DESCRIPTION
The default image size for 'large' image types has been updated from 458px to 640px and jQZoom issue has been resolved.