### PR TITLE
Resolve jQZoom issue on room type detail page

### DIFF
--- a/config/xml/themes/default.xml
+++ b/config/xml/themes/default.xml
@@ -223,7 +223,7 @@
         <image name="small_default" width="98" height="98" products="true" categories="false" manufacturers="true" suppliers="true" scenes="false"/>
         <image name="medium_default" width="125" height="125" products="true" categories="true" manufacturers="true" suppliers="true" scenes="false"/>
         <image name="home_default" width="250" height="250" products="true" categories="false" manufacturers="false" suppliers="false" scenes="false"/>
-        <image name="large_default" width="458" height="458" products="true" categories="false" manufacturers="true" suppliers="true" scenes="false"/>
+        <image name="large_default" width="720" height="720" products="true" categories="false" manufacturers="true" suppliers="true" scenes="false"/>
         <image name="thickbox_default" width="800" height="800" products="true" categories="false" manufacturers="false" suppliers="false" scenes="false"/>
         <image name="category_default" width="870" height="217" products="false" categories="true" manufacturers="false" suppliers="false" scenes="false"/>
         <image name="scene_default" width="870" height="270" products="false" categories="false" manufacturers="false" suppliers="false" scenes="true"/>

--- a/install/data/xml/image_type.xml
+++ b/install/data/xml/image_type.xml
@@ -16,7 +16,7 @@
     <image_type id="small_default" name="small_default" width="98" height="98" products="1" categories="0" manufacturers="1" suppliers="1" scenes="0" stores="0"/>
     <image_type id="medium_default" name="medium_default" width="125" height="125" products="1" categories="1" manufacturers="1" suppliers="1" scenes="0" stores="1"/>
     <image_type id="home_default" name="home_default" width="250" height="250" products="1" categories="0" manufacturers="0" suppliers="0" scenes="0" stores="0"/>
-    <image_type id="large_default" name="large_default" width="458" height="458" products="1" categories="0" manufacturers="1" suppliers="1" scenes="0" stores="0"/>
+    <image_type id="large_default" name="large_default" width="720" height="720" products="1" categories="0" manufacturers="1" suppliers="1" scenes="0" stores="0"/>
     <image_type id="thickbox_default" name="thickbox_default" width="800" height="800" products="1" categories="0" manufacturers="0" suppliers="0" scenes="0" stores="0"/>
     <image_type id="category_default" name="category_default" width="870" height="217" products="0" categories="1" manufacturers="0" suppliers="0" scenes="0" stores="0"/>
     <image_type id="scene_default" name="scene_default" width="870" height="270" products="0" categories="0" manufacturers="0" suppliers="0" scenes="1" stores="0"/>

--- a/themes/hotel-reservation-theme/css/product.css
+++ b/themes/hotel-reservation-theme/css/product.css
@@ -27,8 +27,8 @@
 
 .primary_block .pb-left-column img {
   max-width: 100%;
+  height: auto; }
 
-  height: 100%; }
 a.fancybox-nav {
   outline: 0; }
 


### PR DESCRIPTION
The default image size for 'large' image types has been updated from 458px to 720px and jQZoom issue has been resolved.