### PR TITLE
PHP Version issue in Install of Qloapps 1.5.2

### DIFF
--- a/install/controllers/http/system.php
+++ b/install/controllers/http/system.php
@@ -87,7 +87,7 @@ class InstallControllerHttpSystem extends InstallControllerHttp
                     'title' => $this->l('Required PHP parameters'),
                     'success' => 1,
                     'checks' => array(
-                        'phpversion' => $this->l('Minimum PHP 5.4.0 or later is required'),
+                        'phpversion' => $this->l('Minimum PHP 5.6.0 or later is required'),
                         'upload' => $this->l('Cannot upload files'),
                         'system' => $this->l('Cannot create new files and folders'),
                         'gd' => $this->l('GD library is not installed'),
@@ -133,7 +133,7 @@ class InstallControllerHttpSystem extends InstallControllerHttp
                     'title' => $this->l('Recommended PHP parameters'),
                     'success' => $this->tests['optional']['success'],
                     'checks' => array(
-                        'new_phpversion' => sprintf($this->l('You are using PHP %s version. Soon, the latest PHP version supported by Qloapps will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!'), phpversion()),
+                        'new_phpversion' => sprintf($this->l('You are using PHP %s version. Soon, the latest PHP version supported by Qloapps will be PHP 5.6. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.6 now!'), phpversion()),
                         'register_globals' => $this->l('PHP register_globals option is enabled'),
                         'gz' => $this->l('GZIP compression is not activated'),
                         'mcrypt' => $this->l('Mcrypt extension is not enabled'),


### PR DESCRIPTION
### I am Trying to install Qloapps but i stuck at this step
### i am using PHP 5.5.38 

![image](https://user-images.githubusercontent.com/12833130/153577885-2e5ecda7-1e11-4bd1-8c7d-7f53a5a352be.png)

[ConfigurationTest.php#L146-L154](https://github.com/webkul/hotelcommerce/blob/da3f11f58ced9528091cb8cd6ef1a897ce451681/classes/ConfigurationTest.php#L146-L154)
```php
    public static function test_phpversion()
    {
        return version_compare(substr(phpversion(), 0, 5), '5.6.0', '>=');
    }

    public static function test_new_phpversion()
    {
        return version_compare(substr(phpversion(), 0, 5), '5.6.0', '>=');
    }
```
Qloapps checking for php 5.6.0+ but language string is wrong.