### PR TITLE
Remove order history link for guest account holders on order confirmation page

### DIFF
--- a/themes/hotel-reservation-theme/order-confirmation.tpl
+++ b/themes/hotel-reservation-theme/order-confirmation.tpl
@@ -258,10 +258,10 @@
 				<br />{l s='If you have questions, comments or concerns, please contact our'} <a class="cust_serv_lnk" href="{$link->getPageLink('contact', true)|escape:'html'}">{l s='expert customer support team'}</a>
 			</p>
 		</div>
+		<p class="cart_navigation exclusive">
+			<a class="btn" href="{$link->getPageLink('history', true)|escape:'html':'UTF-8'}" title="{l s='Go to your order history page'}"><i class="icon-chevron-left"></i>{l s='View your order history'}</a>
+		</p>
 	{/if}
-	<p class="cart_navigation exclusive">
-		<a class="btn" href="{$link->getPageLink('history', true)|escape:'html':'UTF-8'}" title="{l s='Go to your order history page'}"><i class="icon-chevron-left"></i>{l s='View your order history'}</a>
-	</p>
 {/if}
 
 {* Fancybox for extra demands*}


### PR DESCRIPTION
This change will not show the unuseful order history link to guest account holders on order confirmation page.