### PR TITLE
Remove unused room status from room type edit page

### DIFF
--- a/admin/themes/default/template/controllers/products/booking.tpl
+++ b/admin/themes/default/template/controllers/products/booking.tpl
@@ -111,10 +111,6 @@
 						<div class="color_indicate bg-red"></div>
 						<span class="indi_label">{l s='Unavailable Rooms'}</span>
 					</div>
-					<div class="col-sm-6 indi_cont clearfix">
-						<div class="color_indicate bg-gray"></div>
-						<span class="indi_label">{l s='Hold For Maintenance'}</span>
-					</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
The status 'Hold for Maintenance' has been removed.