### PR TITLE
Remove smarty modifiers json_encode and json_decode | change in deprecation message

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2648,7 +2648,7 @@ exit;
         if ($message === null) {
             $message = 'The function '.$callee['function'].' (Line '.$callee['line'].') is deprecated and will be removed in the next major version.';
         }
-        $error = 'Function: '.$callee['function'].'() is deprecated in file: '.$callee['file'].' on line: '.$callee['line'].'<br />';
+        $error = 'Function: <b>'.$callee['function'].'()</b> is deprecated in file: <b>'.$callee['file'].'</b> on line: <b>'.$callee['line'].'</b><br />';
 
         Tools::throwDeprecated($error, $message, $class);
     }

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2643,10 +2643,12 @@ exit;
         $backtrace = debug_backtrace();
         $callee = next($backtrace);
         $class = isset($callee['class']) ? $callee['class'] : null;
+        $callee['file'] = isset($callee['file']) ? $callee['file'] : '<undefined>';
+        $callee['line'] = isset($callee['line']) ? $callee['line'] : '<undefined>';
         if ($message === null) {
             $message = 'The function '.$callee['function'].' (Line '.$callee['line'].') is deprecated and will be removed in the next major version.';
         }
-        $error = 'Function <b>'.$callee['function'].'()</b> is deprecated in <b>'.$callee['file'].'</b> on line <b>'.$callee['line'].'</b><br />';
+        $error = 'Function: '.$callee['function'].'() is deprecated in file: '.$callee['file'].' on line: '.$callee['line'].'<br />';
 
         Tools::throwDeprecated($error, $message, $class);
     }

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -93,8 +93,6 @@ smartyRegisterFunction($smarty, 'function', 'd', 'smartyDieObject'); // Debug on
 smartyRegisterFunction($smarty, 'function', 'l', 'smartyTranslate', false);
 smartyRegisterFunction($smarty, 'function', 'hook', 'smartyHook');
 smartyRegisterFunction($smarty, 'function', 'toolsConvertPrice', 'toolsConvertPrice');
-smartyRegisterFunction($smarty, 'modifier', 'json_encode', 'json_encode');
-smartyRegisterFunction($smarty, 'modifier', 'json_decode', 'json_decode');
 smartyRegisterFunction($smarty, 'function', 'dateFormat', array('Tools', 'dateFormat'));
 smartyRegisterFunction($smarty, 'function', 'convertPrice', array('Product', 'convertPrice'));
 smartyRegisterFunction($smarty, 'function', 'convertPriceWithCurrency', array('Product', 'convertPriceWithCurrency'));

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -93,8 +93,8 @@ smartyRegisterFunction($smarty, 'function', 'd', 'smartyDieObject'); // Debug on
 smartyRegisterFunction($smarty, 'function', 'l', 'smartyTranslate', false);
 smartyRegisterFunction($smarty, 'function', 'hook', 'smartyHook');
 smartyRegisterFunction($smarty, 'function', 'toolsConvertPrice', 'toolsConvertPrice');
-smartyRegisterFunction($smarty, 'modifier', 'json_encode', array('Tools', 'jsonEncode'));
-smartyRegisterFunction($smarty, 'modifier', 'json_decode', array('Tools', 'jsonDecode'));
+smartyRegisterFunction($smarty, 'modifier', 'json_encode', 'json_encode');
+smartyRegisterFunction($smarty, 'modifier', 'json_decode', 'json_decode');
 smartyRegisterFunction($smarty, 'function', 'dateFormat', array('Tools', 'dateFormat'));
 smartyRegisterFunction($smarty, 'function', 'convertPrice', array('Product', 'convertPrice'));
 smartyRegisterFunction($smarty, 'function', 'convertPriceWithCurrency', array('Product', 'convertPriceWithCurrency'));


### PR DESCRIPTION
1. Smarty modifiers json_encode and json_decode have been removed in favour of matching php functions.
2. Deprecation message has been changed to handle cases when debug_backtrace() can not provide 'file' and 'line' values.