### PR TITLE
Added upper limit of PHP for QloApps installation

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -145,7 +145,10 @@ class ConfigurationTestCore
 
     public static function test_phpversion()
     {
-        return version_compare(substr(phpversion(), 0, 5), '5.6.0', '>=');
+        return (
+            version_compare(substr(phpversion(), 0, 5), '5.6.0', '>=')
+            && version_compare(substr(phpversion(), 0, 5), '8.0', '<')
+        );
     }
 
     public static function test_new_phpversion()

--- a/controllers/admin/AdminInformationController.php
+++ b/controllers/admin/AdminInformationController.php
@@ -108,7 +108,7 @@ class AdminInformationControllerCore extends AdminController
     public function getTestResult()
     {
         $tests_errors = array(
-            'phpversion' => $this->l('Update your PHP version.'),
+            'phpversion' => $this->l('The required PHP version is between 5.6 to 7.4.'),
             'upload' => $this->l('Configure your server to allow file uploads.'),
             'system' => $this->l('Configure your server to allow the creation of directories and files with write permissions.'),
             'gd' => $this->l('Enable the GD library on your server.'),
@@ -128,7 +128,7 @@ class AdminInformationControllerCore extends AdminController
             'register_globals' => $this->l('Set PHP "register_globals" option to "Off".'),
             'gz' => $this->l('Enable GZIP compression on your server.'),
             'files' => $this->l('Some QloApps files are missing from your server.'),
-            'new_phpversion' => sprintf($this->l('You are using PHP %s version. Soon, the latest PHP version supported by QloApps will be PHP 5.4. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.4 now!'), phpversion()),
+            'new_phpversion' => sprintf($this->l('You are using PHP %s version. Soon, the latest PHP version supported by QloApps will be PHP 5.6. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.6 now!'), phpversion()),
             'pdo_mysql' => $this->l('PDO MySQL extension is not loaded'),
             'openssl' => $this->l('PHP OpenSSL extension is not loaded'),
         );

--- a/install/controllers/http/system.php
+++ b/install/controllers/http/system.php
@@ -87,7 +87,7 @@ class InstallControllerHttpSystem extends InstallControllerHttp
                     'title' => $this->l('Required PHP parameters'),
                     'success' => 1,
                     'checks' => array(
-                        'phpversion' => $this->l('Minimum PHP 5.6.0 or later is required'),
+                        'phpversion' => $this->l('The required PHP version is between 5.6 to 7.4'),
                         'upload' => $this->l('Cannot upload files'),
                         'system' => $this->l('Cannot create new files and folders'),
                         'gd' => $this->l('GD library is not installed'),


### PR DESCRIPTION
Added checking upper limit of PHP (PHP8) during system compatibility checks for QloApps installation.
Stops QloApps installation if installing in PHP 8