### PR TITLE
Resolve room type name font issue at room type detail page

### DIFF
--- a/themes/hotel-reservation-theme/css/product.css
+++ b/themes/hotel-reservation-theme/css/product.css
@@ -1207,7 +1207,6 @@ Quick View Styles
     margin-bottom: 10px;}
 
 .hotel_name_block {
-  font-family: OpenSans;
   font-size: 22px;
   color: #000000;
   margin-bottom: 5px;}


### PR DESCRIPTION
This room type name will now use default Oxygen font on room type detail page.