### PR TITLE
Resolved issue when preview template in backoffice order status page

### DIFF
--- a/mails/.htaccess
+++ b/mails/.htaccess
@@ -1,2 +1,5 @@
 Order deny,allow
 Deny from all
+<FilesMatch "\.(html|txt)$">
+Allow from all
+</FilesMatch>


### PR DESCRIPTION
Updated .htaccess file to allow only "HTML" and "txt" files to be available.