### PR TITLE
Fix tpl path issue on Manage Room Types page

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -5484,10 +5484,9 @@ class AdminProductsControllerCore extends AdminController
         }
         $this->tpl_form_vars['custom_form'] = $data->fetch();
     }
-    
+
     public function getModalDuplicateOptions()
     {
-        $tpl = $this->createTemplate('modal-duplicate-options.tpl');
         $idsHotel = HotelBranchInformation::getProfileAccessedHotels($this->context->employee->id_profile, 1, 1);
         $hotelsInfo = array();
         foreach ($idsHotel as $idHotel) {
@@ -5502,13 +5501,15 @@ class AdminProductsControllerCore extends AdminController
                 $hotelsInfo[] = $hotelInfo;
             }
         }
+
         $formAction = $this->context->link->getAdminLink('AdminProducts', true).'&duplicateproduct';
-        $tpl->assign(array(
+        $this->context->smarty->assign(array(
             'action' => $formAction,
             'hotels_info' => $hotelsInfo,
             'duplicate_images' => 1,
         ));
 
+        $modalContent = $this->context->smarty->fetch('controllers/products/modal-duplicate-options.tpl');
         $modalActions = array(
             array(
                 'type' => 'button',
@@ -5523,9 +5524,10 @@ class AdminProductsControllerCore extends AdminController
             'modal_id' => 'modal-duplicate-options',
             'modal_class' => 'modal-md',
             'modal_title' => $this->l('Duplication options'),
-            'modal_content' => $tpl->fetch(),
+            'modal_content' => $modalContent,
             'modal_actions' => $modalActions,
         );
+
         return $modal;
     }
 


### PR DESCRIPTION
This change resolves the issue of tpl path when an employee clicks a link of a room type with no permission.