### PR TITLE
Fix owl-carousel plugin loading issue for 'wktestimonialblock' module

### DIFF
--- a/modules/wktestimonialblock/wktestimonialblock.php
+++ b/modules/wktestimonialblock/wktestimonialblock.php
@@ -55,7 +55,7 @@ class WkTestimonialBlock extends Module
     {
         $this->context->controller->addCSS(_PS_JS_DIR_.'/owl-carousel/assets/owl.carousel.min.css');
         $this->context->controller->addCSS(_PS_JS_DIR_.'/owl-carousel/assets/owl.theme.default.min.css');
-        $this->context->controller->addJS(_PS_JS_DIR_.'/owl-carousel/owl.carousel.min');
+        $this->context->controller->addJS(_PS_JS_DIR_.'/owl-carousel/owl.carousel.min.js');
 
         $this->context->controller->addCSS($this->_path.'/views/css/WkTestimonialBlockFront.css');
         $this->context->controller->addJS($this->_path.'/views/js/WkTestimonialBlockFront.js');


### PR DESCRIPTION
The jQuery plugin Owl Carousel was not loading on home page due to wrong file name. 