### PR TITLE
Fix Webservice count() issue

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -183,7 +183,7 @@ class WebserviceRequestCore
     public static $ws_current_classname;
 
 
-    public static $shopIDs;
+    public static $shopIDs = array();
 
 
     public function getOutputEnabled()


### PR DESCRIPTION
Using count() on a null variable triggers PHP warning on PHP versions >= 7.2. This change resolves this issue.