### PR TITLE
Fix page scroll issues at order history and order view page

### DIFF
--- a/admin/themes/default/js/admin-theme.js
+++ b/admin/themes/default/js/admin-theme.js
@@ -86,9 +86,8 @@ function error_modal(heading, msg) {
 }
 
 //move to hash after clicking on anchored links
-function scroll_if_anchor(href) {
+function scroll_if_anchor(href, fromTop = 120) {
 	href = typeof(href) === "string" ? href : $(this).attr("href");
-	var fromTop = 120;
 	if(href.indexOf("#") === 0) {
 		var $target = $(href);
 		if($target.length) {

--- a/js/admin/orders.js
+++ b/js/admin/orders.js
@@ -326,16 +326,17 @@ function init()
 
 		$('.edit_product_fields, .standard_refund_fields, .partial_refund_fields, .order_action').hide();
 		$('tr#new_product').slideDown('fast', function () {
-			$('tr#new_product td').fadeIn('fast', function() {
+			$('tr#new_product td').fadeIn('fast').promise().done(function () {
 				$('#add_product_product_name').focus();
-				scroll_if_anchor('#new_product');
+				scroll_if_anchor('#new_product', 360);
 			});
 		});
+
 		e.preventDefault();
 	});
 
 	$('#cancelAddProduct').unbind('click').click(function() {
-		$('.order_action').show();
+		$('.order_action').not('.standard_refund_fields').show();
 		$('tr#new_product td').fadeOut('fast');
 	});
 

--- a/themes/hotel-reservation-theme/js/history.js
+++ b/themes/hotel-reservation-theme/js/history.js
@@ -156,6 +156,11 @@ function sendOrderMessage()
 }
 
 $(document).ready(function(){
+	var page = $('html, body');
+	page.on('mousewheel', function () {
+		page.stop();
+	});
+
 	// If customer clicks for refund request then toggle refund request fields
 	$('body').on('click', '#order_refund_request', function(e) {
 		e.preventDefault();


### PR DESCRIPTION
1. The order history page at front office will now stop scrolling if interrupted by manual scroll using mouse.
2. The manual scroll at order view page at back office will not be interrupted by auto scroll. 