### PR TITLE
Fix module reset options popup issue on Modules & Services page

### DIFF
--- a/admin/themes/default/js/admin-theme.js
+++ b/admin/themes/default/js/admin-theme.js
@@ -460,7 +460,7 @@ $(document).ready(function() {
 
 	// reset form
 	/* global header_confirm_reset, body_confirm_reset, left_button_confirm_reset, right_button_confirm_reset */
-	$(".reset_ready").click(function () {
+	$(document).on('click', '.reset_ready', function () {
 		var href = $(this).attr('href');
 		confirm_modal( header_confirm_reset, body_confirm_reset, left_button_confirm_reset, right_button_confirm_reset,
 			function () {


### PR DESCRIPTION
The popup does not appear if module list is fetched via ajax when a filter is applied.