### PR TITLE
Improvement of cart rule applied on orders and room types

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1783,7 +1783,7 @@ class CartCore extends ObjectModel
             $order_total_discount = min(Tools::ps_round($order_total_discount, 2), (float)$order_total_products) + (float)$order_shipping_discount;
             if ($type == Cart::ADVANCE_PAYMENT) {
                 // get order total without discount
-                $total_without_discount = self::getOrderTotal() + $order_total_discount;
+                $total_without_discount = $this->getOrderTotal() + $order_total_discount;
                 // to find due amount substract advance payment without discuount from order total without discount
                 // Due Amount = order total - advance payment (without discount)
                 $due_amount = $total_without_discount - $order_total;

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -875,6 +875,7 @@ class CartRuleCore extends ObjectModel
      * @param bool $use_tax
      * @param Context $context
      * @param bool $use_cache Allow using cache to avoid multiple free gift using multishipping
+     * @param bool $only_advance_payment_products to calculate discount applied only on products that have advance payment
      * @return float|int|string
      */
     public function getContextualValue($use_tax, Context $context = null, $filter = null, $package = null, $use_cache = true, $only_advance_payment_products = false)
@@ -903,8 +904,8 @@ class CartRuleCore extends ObjectModel
         $cache_id = 'getContextualValue_'.(int)$this->id.'_'.(int)$use_tax.'_'.(int)$context->cart->id.'_'.(int)$filter.'_'.(int)$only_advance_payment_products;
         foreach ($package['products'] as $key => $product) {
             if ($only_advance_payment_products) {
-                if ($paymentInfo = $objHotelAdvancePayment->getIdAdvPaymentByIdProduct($product['id_product'])) {
-                    if (!$paymentInfo['active']) {
+                if ($advancePaymentInfo = $objHotelAdvancePayment->getIdAdvPaymentByIdProduct($product['id_product'])) {
+                    if (!$advancePaymentInfo['active']) {
                         unset($package['products'][$key]);
                         continue;
                     }

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1041,19 +1041,29 @@ class CartRuleCore extends ObjectModel
                     }
                 }
 
+                $restricted_product = null;
                 $reduction_amount = $this->reduction_amount;
-                if ($this->reduction_product) {
-                    if ($restricted_product) {
-                        $prorata = 1; // do not split this cart rule
-                        if ($this->reduction_tax) {
-                            $max_reduction_amount = (int)$restricted_product['cart_quantity'] * (float)$restricted_product['price_wt'];
-                        } else {
-                            $max_reduction_amount = (int)$restricted_product['cart_quantity'] * (float)$restricted_product['price'];
+                // If the cart rule is restricted to one room type it can't exceed this room type price
+                if ($this->reduction_product > 0) {
+                    foreach ($package_products as $product) {
+                        if ($product['id_product'] == $this->reduction_product) {
+                            $restricted_product = $product;
+
+                            $prorata = 1; // do not split this cart rule
+                            if ($this->reduction_tax) {
+                                $max_reduction_amount = (int) $restricted_product['cart_quantity'] * (float) $restricted_product['price_wt'];
+                            } else {
+                                $max_reduction_amount = (int) $restricted_product['cart_quantity'] * (float) $restricted_product['price'];
+                            }
+                            $reduction_amount = min($reduction_amount, $max_reduction_amount);
+
+                            break;
                         }
-                        $reduction_amount = min($reduction_amount, $max_reduction_amount);
-                    } else {
-                        $reduction_amount = 0;
                     }
+                }
+
+                if (($this->reduction_product > 0) && !$restricted_product) {
+                    $reduction_amount = 0;
                 }
 
                 // If we need to convert the voucher value to the cart currency

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1032,16 +1032,6 @@ class CartRuleCore extends ObjectModel
                 }
 
                 $restricted_product = null;
-                // If the cart rule is restricted to one room type it can't exceed this room type price
-                if ($this->reduction_product > 0) {
-                    foreach ($package_products as $product) {
-                        if ($product['id_product'] == $this->reduction_product) {
-                            $restricted_product = $product;
-                        }
-                    }
-                }
-
-                $restricted_product = null;
                 $reduction_amount = $this->reduction_amount;
                 // If the cart rule is restricted to one room type it can't exceed this room type price
                 if ($this->reduction_product > 0) {

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -544,8 +544,6 @@ abstract class PaymentModuleCore extends Module
                     }
 
                     $cart_rules_list = array();
-                    $total_reduction_value_ti = 0;
-                    $total_reduction_value_tex = 0;
                     foreach ($cart_rules as $cart_rule) {
                         if ($cart_rule['obj']->reduction_product > 0 && !$order->orderContainProduct($cart_rule['obj']->reduction_product)) {
                             continue;
@@ -563,7 +561,6 @@ abstract class PaymentModuleCore extends Module
                         }
 
                         // IF
-                        //	This is not multi-shipping
                         //	The value of the voucher is greater than the total of the order
                         //	Partial use is allowed
                         //	This is an "amount" reduction, not a reduction in % or a gift
@@ -582,7 +579,7 @@ abstract class PaymentModuleCore extends Module
                         } else {
                             $remaining_amount = $reduction_amount_converted - $values['tax_excl'];
                         }
-                        if (count($order_list) == 1 && $remaining_amount > 0 && $cart_rule['obj']->partial_use == 1 && $reduction_amount_converted > 0) {
+                        if ($remaining_amount > 0 && $cart_rule['obj']->partial_use == 1 && $reduction_amount_converted > 0) {
                             // Create a new voucher from the original
                             $voucher = new CartRule((int)$cart_rule['obj']->id); // We need to instantiate the CartRule without lang parameter to allow saving it
                             unset($voucher->id);
@@ -642,12 +639,7 @@ abstract class PaymentModuleCore extends Module
                                     null, null, null, null, _PS_MAIL_DIR_, false, (int)$order->id_shop
                                 );
                             }
-
-                            $values['tax_incl'] = $order->total_products_wt - $total_reduction_value_ti;
-                            $values['tax_excl'] = $order->total_products - $total_reduction_value_tex;
                         }
-                        $total_reduction_value_ti += $values['tax_incl'];
-                        $total_reduction_value_tex += $values['tax_excl'];
 
                         $order->addCartRule($cart_rule['obj']->id, $cart_rule['obj']->name, $values, 0, $cart_rule['obj']->free_shipping);
 


### PR DESCRIPTION
- During advance payment, the cart rule should be applied on the due amount, not on the pre-payment.
  - This PR first applies cart rule discount on the due amount, if the cart rule amount is greater than the due amount then it is applied on advance payment.
- Voucher with restricted room type and in case of multiple orders should not be split to other hotels.
- Fixes voucher creation issues for remaining amount in case of multiple orders
- Fixes wrong discount amount update on order_cart_rule table.