### PR TITLE
Security update:  Allow admin user to configure the SameSite cookie attribute

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -30,20 +30,20 @@ class CookieCore
     const SAMESITE_LAX = 'Lax';
     const SAMESITE_STRICT = 'Strict';
 
-    const SAMESITE_AVAILABLE_VALUES = [
-        [
+    const SAMESITE_AVAILABLE_VALUES = array(
+        array(
             "type" => self::SAMESITE_NONE,
             "name" => self::SAMESITE_NONE
-        ],
-        [
+        ),
+        array(
             "type" => self::SAMESITE_LAX,
             "name" => self::SAMESITE_LAX
-        ],
-        [
+        ),
+        array(
             "type" => self::SAMESITE_STRICT,
             "name" => self::SAMESITE_STRICT
-        ],
-    ];
+        ),
+    );
 
     /** @var array Contain cookie content in a key => value format */
     protected $_content;

--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -26,6 +26,25 @@
 
 class CookieCore
 {
+    const SAMESITE_NONE = 'None';
+    const SAMESITE_LAX = 'Lax';
+    const SAMESITE_STRICT = 'Strict';
+
+    const SAMESITE_AVAILABLE_VALUES = [
+        [
+            "type" => self::SAMESITE_NONE,
+            "name" => self::SAMESITE_NONE
+        ],
+        [
+            "type" => self::SAMESITE_LAX,
+            "name" => self::SAMESITE_LAX
+        ],
+        [
+            "type" => self::SAMESITE_STRICT,
+            "name" => self::SAMESITE_STRICT
+        ],
+    ];
+
     /** @var array Contain cookie content in a key => value format */
     protected $_content;
 
@@ -73,6 +92,7 @@ class CookieCore
         $this->_path = str_replace('%2F', '/', $this->_path);
         $this->_path = str_replace('%7E', '~', $this->_path);
         $this->_domain = $this->getDomain($shared_urls);
+        $this->_sameSite = Configuration::get('PS_COOKIE_SAMESITE');
         $this->_name = 'PrestaShop-'.md5(($this->_standalone ? '' : _PS_VERSION_).$name.$this->_domain);
         $this->_allow_writing = true;
         $this->_salt = $this->_standalone ? str_pad('', 8, md5('ps'.__FILE__)) : _COOKIE_IV_;
@@ -82,7 +102,7 @@ class CookieCore
         } else {
             $this->_cipherTool = new PhpEncryption(_NEW_COOKIE_KEY_);
         }
-        
+
         $this->_secure = (bool)$secure;
 
         $this->update();
@@ -342,11 +362,35 @@ class CookieCore
             $content = 0;
             $time = 1;
         }
-        if (PHP_VERSION_ID <= 50200) { /* PHP version > 5.2.0 */
-            return setcookie($this->_name, $content, $time, $this->_path, $this->_domain, $this->_secure);
-        } else {
-            return setcookie($this->_name, $content, $time, $this->_path, $this->_domain, $this->_secure, true);
+
+        /*
+         * The alternative signature supporting an options array is only available since
+         * PHP 7.3.0, before there is no support for SameSite attribute.
+         */
+        if (PHP_VERSION_ID < 70300) {
+            return setcookie(
+                $this->_name,
+                $content,
+                $time,
+                $this->_path,
+                $this->_domain . '; SameSite=' . $this->_sameSite,
+                $this->_secure,
+                true
+            );
         }
+
+        return setcookie(
+            $this->_name,
+            $content,
+            [
+                'expires' => $time,
+                'path' => $this->_path,
+                'domain' => $this->_domain,
+                'secure' => $this->_secure,
+                'httponly' => true,
+                'samesite' => $this->_sameSite,
+            ]
+        );
     }
 
     public function __destruct()

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -159,10 +159,10 @@ if ($cookie_lifetime > 0) {
     $cookie_lifetime = time() + (max($cookie_lifetime, 1) * 3600);
 }
 
+$force_ssl = Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE');
 if (defined('_PS_ADMIN_DIR_')) {
-    $cookie = new Cookie('psAdmin', '', $cookie_lifetime);
+    $cookie = new Cookie('psAdmin', '', $cookie_lifetime, null, false, $force_ssl);
 } else {
-    $force_ssl = Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE');
     if ($context->shop->getGroup()->share_order) {
         $cookie = new Cookie('ps-sg'.$context->shop->getGroup()->id, '', $cookie_lifetime, $context->shop->getUrlsSharedCart(), false, $force_ssl);
     } else {

--- a/controllers/admin/AdminAdminPreferencesController.php
+++ b/controllers/admin/AdminAdminPreferencesController.php
@@ -85,6 +85,16 @@ class AdminAdminPreferencesControllerCore extends AdminController
                         'default' => '480',
                         'visibility' => Shop::CONTEXT_ALL
                     ),
+                    'PS_COOKIE_SAMESITE' => array(
+                        'title' => $this->l('Same site cookie'),
+                        'hint' => $this->l('Allows you to declare if your cookie should be restricted to a first-party or same-site context.'),
+                        'validation' => 'isGenericName',
+                        'type' => 'select',
+                        'cast' => 'strval',
+                        'identifier' => 'type',
+                        'list' => CookieCore::SAMESITE_AVAILABLE_VALUES,
+                        'visibility' => Shop::CONTEXT_ALL
+                    ),
                 ),
                 'submit' => array('title' => $this->l('Save'))
             ),
@@ -159,6 +169,12 @@ class AdminAdminPreferencesControllerCore extends AdminController
         $upload_max_size = (int)str_replace('M', '', ini_get('upload_max_filesize'));
         $post_max_size = (int)str_replace('M', '', ini_get('post_max_size'));
         $max_size = $upload_max_size < $post_max_size ? $upload_max_size : $post_max_size;
+        $forceSsl = Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE');
+
+        if (!$forceSsl && Tools::getValue('PS_COOKIE_SAMESITE') === Cookie::SAMESITE_NONE) {
+            $this->errors[] = Tools::displayError('The SameSite=None is only available in secure mode.');
+            return;
+        }
 
         if (Tools::getValue('PS_LIMIT_UPLOAD_FILE_VALUE') > $max_size || Tools::getValue('PS_LIMIT_UPLOAD_IMAGE_VALUE') > $max_size) {
             $this->errors[] = Tools::displayError('The limit chosen is larger than the server\'s maximum upload limit. Please increase the limits of your server.');

--- a/install/data/xml/configuration.xml
+++ b/install/data/xml/configuration.xml
@@ -437,6 +437,9 @@
 	<configuration id="PS_COOKIE_LIFETIME_BO" name="PS_COOKIE_LIFETIME_BO">
 		<value>480</value>
 	</configuration>
+	<configuration id="PS_COOKIE_SAMESITE" name="PS_COOKIE_SAMESITE">
+		<value>Lax</value>
+	</configuration>
 	<configuration id="PS_RESTRICT_DELIVERED_COUNTRIES" name="PS_RESTRICT_DELIVERED_COUNTRIES">
 		<value>0</value>
 	</configuration>


### PR DESCRIPTION
Added a feature that allows the admin user to configure the SameSite cookie attribute