### PR TITLE
Fix PHP error on passing wrong dates in URL

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -427,6 +427,11 @@ class ToolsCore
         return isset($_POST[$key]) ? true : (isset($_GET[$key]) ? true : false);
     }
 
+    public static function getQueryString()
+    {
+        return isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '';
+    }
+
     /**
     * Change language in cookie while clicking on a flag
     *

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -427,11 +427,6 @@ class ToolsCore
         return isset($_POST[$key]) ? true : (isset($_GET[$key]) ? true : false);
     }
 
-    public static function getQueryString()
-    {
-        return isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '';
-    }
-
     /**
     * Change language in cookie while clicking on a flag
     *

--- a/controllers/front/CategoryController.php
+++ b/controllers/front/CategoryController.php
@@ -95,6 +95,18 @@ class CategoryControllerCore extends FrontController
             $this->errors[] = Tools::displayError('Missing category ID');
         }
 
+        // validate dates if available
+        $dateFrom = Tools::getValue('date_from');
+        $dateTo = Tools::getValue('date_to');
+
+        if ($dateFrom != '' && !Validate::isDate($dateFrom)) {
+            Tools::redirect($this->context->link->getPageLink('pagenotfound'));
+        }
+
+        if ($dateTo != '' && !Validate::isDate($dateTo)) {
+            Tools::redirect($this->context->link->getPageLink('pagenotfound'));
+        }
+
         // Instantiate category
         $this->category = new Category($id_category, $this->context->language->id);
 

--- a/controllers/front/CategoryController.php
+++ b/controllers/front/CategoryController.php
@@ -95,32 +95,20 @@ class CategoryControllerCore extends FrontController
             $this->errors[] = Tools::displayError('Missing category ID');
         }
 
-        // Instantiate category
-        $this->category = new Category($id_category, $this->context->language->id);
-
-        // validate dates if available and redirect if invalid
-        $hasInvalidDates = false;
+        // validate dates if available
         $dateFrom = Tools::getValue('date_from');
         $dateTo = Tools::getValue('date_to');
 
         if ($dateFrom != '' && !Validate::isDate($dateFrom)) {
-            $dateFrom = date('Y-m-d');
-            $dateTo = date('Y-m-d', strtotime('+1 day', strtotime($dateFrom)));
-            $hasInvalidDates = true;
-        } elseif ($dateTo != '' && !Validate::isDate($dateTo)) {
-            $dateTo = date('Y-m-d', strtotime('+1 day', strtotime($dateFrom)));
-            $hasInvalidDates = true;
+            Tools::redirect($this->context->link->getPageLink('pagenotfound'));
         }
 
-        if ($hasInvalidDates) {
-            $queryString = Tools::getQueryString();
-            parse_str($queryString, $queryParams);
-            $urlParams = array_merge($queryParams, array('date_from' => $dateFrom, 'date_to' => $dateTo));
-            $redirectLink = $this->context->link->getCategoryLink($this->category, null, $this->context->language->id).
-            (Configuration::get('PS_REWRITING_SETTINGS') ? '?' : '&').http_build_query($urlParams);
-
-            Tools::redirect($redirectLink);
+        if ($dateTo != '' && !Validate::isDate($dateTo)) {
+            Tools::redirect($this->context->link->getPageLink('pagenotfound'));
         }
+
+        // Instantiate category
+        $this->category = new Category($id_category, $this->context->language->id);
 
         parent::init();
 

--- a/controllers/front/CategoryController.php
+++ b/controllers/front/CategoryController.php
@@ -105,15 +105,17 @@ class CategoryControllerCore extends FrontController
 
         if ($dateFrom != '' && !Validate::isDate($dateFrom)) {
             $dateFrom = date('Y-m-d');
-            $dateTo = date('Y-m-d', strtotime($dateFrom) + 86400);
+            $dateTo = date('Y-m-d', strtotime('+1 day', strtotime($dateFrom)));
             $hasInvalidDates = true;
         } elseif ($dateTo != '' && !Validate::isDate($dateTo)) {
-            $dateTo = date('Y-m-d', strtotime($dateFrom) + 86400);
+            $dateTo = date('Y-m-d', strtotime('+1 day', strtotime($dateFrom)));
             $hasInvalidDates = true;
         }
 
         if ($hasInvalidDates) {
-            $urlParams = array('date_from' => $dateFrom, 'date_to' => $dateTo);
+            $queryString = Tools::getQueryString();
+            parse_str($queryString, $queryParams);
+            $urlParams = array_merge($queryParams, array('date_from' => $dateFrom, 'date_to' => $dateTo));
             $redirectLink = $this->context->link->getCategoryLink($this->category, null, $this->context->language->id).
             (Configuration::get('PS_REWRITING_SETTINGS') ? '?' : '&').http_build_query($urlParams);
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -81,34 +81,22 @@ class ProductControllerCore extends FrontController
      */
     public function init()
     {
-        parent::init();
-
-        if ($id_product = (int) Tools::getValue('id_product')) {
-            $this->product = new Product($id_product, true, $this->context->language->id, $this->context->shop->id);
-        }
-
-        // validate dates if available and redirect if invalid
-        $hasInvalidDates = false;
+        // validate dates if available
         $dateFrom = Tools::getValue('date_from');
         $dateTo = Tools::getValue('date_to');
 
         if ($dateFrom != '' && !Validate::isDate($dateFrom)) {
-            $dateFrom = date('Y-m-d');
-            $dateTo = date('Y-m-d', strtotime('+1 day', strtotime($dateFrom)));
-            $hasInvalidDates = true;
-        } elseif ($dateTo != '' && !Validate::isDate($dateTo)) {
-            $dateTo = date('Y-m-d', strtotime('+1 day', strtotime($dateFrom)));
-            $hasInvalidDates = true;
+            Tools::redirect($this->context->link->getPageLink('pagenotfound'));
         }
 
-        if ($hasInvalidDates) {
-            $queryString = Tools::getQueryString();
-            parse_str($queryString, $queryParams);
-            $urlParams = array_merge($queryParams, array('date_from' => $dateFrom, 'date_to' => $dateTo));
-            $redirectLink = $this->context->link->getProductLink($this->product, null, $this->context->language->id).
-            (Configuration::get('PS_REWRITING_SETTINGS') ? '?' : '&').http_build_query($urlParams);
+        if ($dateTo != '' && !Validate::isDate($dateTo)) {
+            Tools::redirect($this->context->link->getPageLink('pagenotfound'));
+        }
 
-            Tools::redirect($redirectLink);
+        parent::init();
+
+        if ($id_product = (int) Tools::getValue('id_product')) {
+            $this->product = new Product($id_product, true, $this->context->language->id, $this->context->shop->id);
         }
 
         if (!Validate::isLoadedObject($this->product)) {

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -81,6 +81,18 @@ class ProductControllerCore extends FrontController
      */
     public function init()
     {
+        // validate dates if available
+        $dateFrom = Tools::getValue('date_from');
+        $dateTo = Tools::getValue('date_to');
+
+        if ($dateFrom != '' && !Validate::isDate($dateFrom)) {
+            Tools::redirect($this->context->link->getPageLink('pagenotfound'));
+        }
+
+        if ($dateTo != '' && !Validate::isDate($dateTo)) {
+            Tools::redirect($this->context->link->getPageLink('pagenotfound'));
+        }
+
         parent::init();
 
         if ($id_product = (int) Tools::getValue('id_product')) {

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -94,15 +94,17 @@ class ProductControllerCore extends FrontController
 
         if ($dateFrom != '' && !Validate::isDate($dateFrom)) {
             $dateFrom = date('Y-m-d');
-            $dateTo = date('Y-m-d', strtotime($dateFrom) + 86400);
+            $dateTo = date('Y-m-d', strtotime('+1 day', strtotime($dateFrom)));
             $hasInvalidDates = true;
         } elseif ($dateTo != '' && !Validate::isDate($dateTo)) {
-            $dateTo = date('Y-m-d', strtotime($dateFrom) + 86400);
+            $dateTo = date('Y-m-d', strtotime('+1 day', strtotime($dateFrom)));
             $hasInvalidDates = true;
         }
 
         if ($hasInvalidDates) {
-            $urlParams = array('date_from' => $dateFrom, 'date_to' => $dateTo);
+            $queryString = Tools::getQueryString();
+            parse_str($queryString, $queryParams);
+            $urlParams = array_merge($queryParams, array('date_from' => $dateFrom, 'date_to' => $dateTo));
             $redirectLink = $this->context->link->getProductLink($this->product, null, $this->context->language->id).
             (Configuration::get('PS_REWRITING_SETTINGS') ? '?' : '&').http_build_query($urlParams);
 


### PR DESCRIPTION
This change resolves PHP errors on Search results and Room type detail pages. User is redirected to the same page with correct dates preserving other URL parameters.