### PR TITLE
Fix PHP error on passing wrong dates in URL

### DIFF
--- a/controllers/front/CategoryController.php
+++ b/controllers/front/CategoryController.php
@@ -95,6 +95,18 @@ class CategoryControllerCore extends FrontController
             $this->errors[] = Tools::displayError('Missing category ID');
         }
 
+        // validate dates if available
+        $dateFrom = Tools::getValue('date_from');
+        $dateTo = Tools::getValue('date_to');
+
+        if ($dateFrom != '' && !Validate::isDate($dateFrom)) {
+            Tools::redirect($this->context->link->getPageLink('pagenotfound'));
+        }
+
+        if ($dateTo != '' && !Validate::isDate($dateTo)) {
+            Tools::redirect($this->context->link->getPageLink('pagenotfound'));
+        }
+
         // Instantiate category
         $this->category = new Category($id_category, $this->context->language->id);
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -88,6 +88,18 @@ class ProductControllerCore extends FrontController
      */
     public function init()
     {
+        // validate dates if available
+        $dateFrom = Tools::getValue('date_from');
+        $dateTo = Tools::getValue('date_to');
+
+        if ($dateFrom != '' && !Validate::isDate($dateFrom)) {
+            Tools::redirect($this->context->link->getPageLink('pagenotfound'));
+        }
+
+        if ($dateTo != '' && !Validate::isDate($dateTo)) {
+            Tools::redirect($this->context->link->getPageLink('pagenotfound'));
+        }
+
         parent::init();
 
         if ($id_product = (int) Tools::getValue('id_product')) {


### PR DESCRIPTION
The user is now redirected to the 'Page not found' page if wrong dates are passed in URL.