### PR TITLE
Resolved: logo visible bigger than recomended size in default theme

### DIFF
--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -144,7 +144,7 @@ class AdminThemesControllerCore extends AdminController
                 'fields' => array(
                     'PS_LOGO' => array(
                         'title' => $this->l('Header logo'),
-                        'hint' => $this->l('Will appear on main page. Recommended height: 52px. Maximum height on default theme: 65px.'),
+                        'hint' => $this->l('Will appear on header of website. Maximum height on default theme: 60px.'),
                         'type' => 'file',
                         'name' => 'PS_LOGO',
                         'tab' => 'logo',
@@ -153,7 +153,7 @@ class AdminThemesControllerCore extends AdminController
                     'PS_LOGO_MOBILE' => array(
                         'title' => $this->l('Header logo for mobile'),
                         'desc' => ((Configuration::get('PS_LOGO_MOBILE') === false) ? '<span class="light-warning">'.$this->l('Warning: No mobile logo has been defined. The header logo will be used instead.').'</span><br />' : ''),
-                        'hint' => $this->l('Will appear on the main page of your mobile template. If left undefined, the header logo will be used.'),
+                        'hint' => $this->l('Will appear on the header of your mobile template. If left undefined, the header logo will be used.'),
                         'type' => 'file',
                         'name' => 'PS_LOGO_MOBILE',
                         'tab' => 'mobile',

--- a/themes/hotel-reservation-theme/css/global.css
+++ b/themes/hotel-reservation-theme/css/global.css
@@ -5818,8 +5818,7 @@ header {
     header .row #header_logo {
       padding: 10px 0; }
     header .row #header_logo img {
-      max-width: 120px;
-      max-height: 120px; }
+      max-height: 60px; }
     header .header-top > div > div > div .header-top-menu {
       display: flex;
       flex-direction: row-reverse;

--- a/themes/hotel-reservation-theme/header.tpl
+++ b/themes/hotel-reservation-theme/header.tpl
@@ -105,7 +105,7 @@
 								<div class="col-xs-12">
 									<div id="header_logo">
 										<a href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" title="{$shop_name|escape:'html':'UTF-8'}">
-											<img class="logo img-responsive" src="{$logo_url}" alt="{$shop_name|escape:'html':'UTF-8'}"{if isset($logo_image_width) && $logo_image_width} width="{$logo_image_width}"{/if}{if isset($logo_image_height) && $logo_image_height} height="{$logo_image_height}"{/if}/>
+											<img class="logo img-responsive" src="{$logo_url}" alt="{$shop_name|escape:'html':'UTF-8'}"/>
 										</a>
 									</div>
 									<div class="header-top-menu">


### PR DESCRIPTION
When logo is uploded bigger than recomended size, it is visible in full size but it should be contained within the header