### PR TITLE
Added: SQL_MODE for allow invalid dates in db backup

### DIFF
--- a/classes/PrestaShopBackup.php
+++ b/classes/PrestaShopBackup.php
@@ -218,7 +218,8 @@ class PrestaShopBackupCore
         $this->id = realpath($backupfile);
 
         fwrite($fp, '/* Backup for '.Tools::getHttpHost(false, false).__PS_BASE_URI__."\n *  at ".date($date)."\n */\n");
-        fwrite($fp, "\n".'SET NAMES \'utf8\';'."\n\n");
+        fwrite($fp, "\n".'SET NAMES \'utf8\';');
+        fwrite($fp, "\n".'SET SQL_MODE=\'ALLOW_INVALID_DATES\';'."\n\n");
 
         // Find all tables
         $tables = Db::getInstance()->executeS('SHOW TABLES');


### PR DESCRIPTION
In Database backup dates were in 00-00-0000 format which failed Db restore in MYSQL. So added ALLOW_INVALID_DATES to resolve this issue