### PR TITLE
Improved: Enable ssl configuration during installation

### DIFF
--- a/install/controllers/http/configure.php
+++ b/install/controllers/http/configure.php
@@ -312,6 +312,17 @@ class InstallControllerHttpConfigure extends InstallControllerHttp
             $this->session->enable_ssl = Tools::usingSecureMode() ? '1' : '0';
         }
 
+        $this->ssl_url = 'https://'.$_SERVER['HTTP_HOST'].$_SERVER['SCRIPT_NAME'];
+
+        if (!isset($this->session->allow_ssl) || $this->session->allow_ssl === false) {
+            if (Tools::usingSecureMode()) {
+                $this->session->enable_ssl = '1';
+                $this->session->allow_ssl = true;
+            } else {
+                $this->session->allow_ssl = false;
+            }
+        }
+
         $this->displayTemplate('configure');
     }
 

--- a/install/controllers/http/configure.php
+++ b/install/controllers/http/configure.php
@@ -307,18 +307,12 @@ class InstallControllerHttpConfigure extends InstallControllerHttp
         // Install type
         $this->install_type = ($this->session->install_type) ? $this->session->install_type : 'full';
 
-        // Detect SSL mode
-        if (!isset($this->session->enable_ssl)) {
-            $this->session->enable_ssl = Tools::usingSecureMode() ? '1' : '0';
-        }
-
-        $this->ssl_url = 'https://'.$_SERVER['HTTP_HOST'].$_SERVER['SCRIPT_NAME'];
-
         if (!isset($this->session->allow_ssl) || $this->session->allow_ssl === false) {
             if (Tools::usingSecureMode()) {
                 $this->session->enable_ssl = '1';
                 $this->session->allow_ssl = true;
             } else {
+                $this->session->enable_ssl = '0';
                 $this->session->allow_ssl = false;
             }
         }

--- a/install/theme/views/configure.phtml
+++ b/install/theme/views/configure.phtml
@@ -83,9 +83,9 @@ var default_iso = '<?php echo $this->session->shop_country ?>';
 	</div>
 
 	<!-- Enable SSL -->
-	<div class="field clearfix">
-		<label class="aligned"><?php echo $this->l('Enable SSL') ?></label>
-		<?php if ($this->session->allow_ssl) { ?>
+	<?php if ($this->session->allow_ssl) { ?>
+		<div class="field clearfix">
+			<label class="aligned"><?php echo $this->l('Enable SSL') ?></label>
 			<div class="contentinput">
 				<label>
 					<input value="1" type="radio" name="enable_ssl" style="vertical-align: middle;" <?php if ($this->session->enable_ssl == '1'): ?>checked="checked"<?php endif; ?> autocomplete="off" />
@@ -96,12 +96,8 @@ var default_iso = '<?php echo $this->session->shop_country ?>';
 					<?php echo $this->l('No'); ?>
 				</label>
 			</div>
-		<?php } else { ?>
-			<div class="contentinput">
-				<a href="<?php echo $this->ssl_url ?>"><?php echo $this->l('Please click here to check if your server supports HTTPS.') ?></a>
-			</div>
-		<?php } ?>
-	</div>
+		</div>
+	<?php } ?>
 
 	<!-- Shop logo
 	<div class="field clearfix">

--- a/install/theme/views/configure.phtml
+++ b/install/theme/views/configure.phtml
@@ -85,16 +85,22 @@ var default_iso = '<?php echo $this->session->shop_country ?>';
 	<!-- Enable SSL -->
 	<div class="field clearfix">
 		<label class="aligned"><?php echo $this->l('Enable SSL') ?></label>
-		<div class="contentinput">
-			<label>
-				<input value="1" type="radio" name="enable_ssl" style="vertical-align: middle;" <?php if ($this->session->enable_ssl == '1'): ?>checked="checked"<?php endif; ?> autocomplete="off" />
-				<?php echo $this->l('Yes') ?>
-			</label>
-			<label>
-				<input value="0" type="radio" name="enable_ssl" style="vertical-align: middle;" <?php if ($this->session->enable_ssl == '0'): ?>checked="checked"<?php endif; ?> autocomplete="off" />
-				<?php echo $this->l('No'); ?>
-			</label>
-		</div>
+		<?php if ($this->session->allow_ssl) { ?>
+			<div class="contentinput">
+				<label>
+					<input value="1" type="radio" name="enable_ssl" style="vertical-align: middle;" <?php if ($this->session->enable_ssl == '1'): ?>checked="checked"<?php endif; ?> autocomplete="off" />
+					<?php echo $this->l('Yes') ?>
+				</label>
+				<label>
+					<input value="0" type="radio" name="enable_ssl" style="vertical-align: middle;" <?php if ($this->session->enable_ssl == '0'): ?>checked="checked"<?php endif; ?> autocomplete="off" />
+					<?php echo $this->l('No'); ?>
+				</label>
+			</div>
+		<?php } else { ?>
+			<div class="contentinput">
+				<a href="<?php echo $this->ssl_url ?>"><?php echo $this->l('Please click here to check if your server supports HTTPS.') ?></a>
+			</div>
+		<?php } ?>
 	</div>
 
 	<!-- Shop logo


### PR DESCRIPTION
During installation, QloApps first check if server actually supports ssl before showing "Enable ssl" configuration