### PR TITLE
Fixed: incorrect payment amount adding from addOrderPaymentDetail

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1781,7 +1781,7 @@ class OrderCore extends ObjectModel
     public function addOrderPaymentDetail(OrderPayment $payment, $amount = null, $order_invoice = null)
     {
         if (Validate::isLoadedObject($payment)) {
-            if (!is_null($amount)) {
+            if (is_null($amount)) {
                 $amount = $payment->amount;
             }
             $order_payment_detail = new OrderPaymentDetail();


### PR DESCRIPTION
Payment amount is ignored when payment amount is passed in `addOrderPaymentDetail` function.
