### PR TITLE
Fixed:  Download module error showing when checking for update on manage module page

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1766,8 +1766,12 @@ abstract class ModuleCore
     public static function refreshModuleList($force_reload_cache = false)
     {
         $status = false;
-        if (!Tools::isFresh(Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, _TIME_1_DAY_) || $force_reload_cache) {
-            if (file_put_contents(_PS_ROOT_DIR_.Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, Tools::addonsRequest('native'))) {
+
+        if (!Tools::isFresh(Module::CACHE_FILE_MODULES_LIST, _TIME_1_DAY_) || $force_reload_cache) {
+            $xml_modules_list = _QLO_API_DOMAIN_.'/xml/'.str_replace('.', '', _QLOAPPS_VERSION_).'.xml';
+            if (Tools::refresh(Module::CACHE_FILE_MODULES_LIST, 'https://'.$xml_modules_list)) {
+                $status = 'refresh';
+            } elseif (Tools::refresh(Module::CACHE_FILE_MODULES_LIST, 'http://'.$xml_modules_list)) {
                 $status = 'refresh';
             } else {
                 $status = 'error';
@@ -1776,24 +1780,52 @@ abstract class ModuleCore
             $status = 'cache';
         }
 
-        if (!Tools::isFresh(Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, _TIME_1_DAY_) || $force_reload_cache) {
-            if (file_put_contents(_PS_ROOT_DIR_.Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, Tools::addonsRequest('must-have'))) {
-                $status = 'refresh';
+        if ($status != 'error') {
+            if (!Tools::isFresh(Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, _TIME_1_DAY_) || $force_reload_cache) {
+                if (file_put_contents(_PS_ROOT_DIR_.Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, Tools::addonsRequest('native'))) {
+                    $status = 'refresh';
+                } else {
+                    $status = 'error';
+                }
             } else {
-                $status = 'error';
+                $status = 'cache';
             }
-        } else {
-            $status = 'cache';
         }
 
-        if (!Tools::isFresh(Module::CACHE_FILE_TAB_MODULES_LIST, _TIME_1_WEEK_)) {
-            if (Tools::refresh(Module::CACHE_FILE_TAB_MODULES_LIST, _QLO_TAB_MODULE_LIST_URL_)) {
-                $status = 'refresh';
+        if ($status != 'error') {
+            if (!Tools::isFresh(Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, _TIME_1_DAY_) || $force_reload_cache) {
+                if (file_put_contents(_PS_ROOT_DIR_.Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, Tools::addonsRequest('must-have'))) {
+                    $status = 'refresh';
+                } else {
+                    $status = 'error';
+                }
             } else {
-                $status = 'error';
+                $status = 'cache';
             }
-        } else {
-            $status = 'cache';
+        }
+
+        if ($status != 'error') {
+            if (!Tools::isFresh(Module::CACHE_FILE_ADDONS_MODULES_LIST, _TIME_1_DAY_) || $force_reload_cache) {
+                if (file_put_contents(_PS_ROOT_DIR_.Module::CACHE_FILE_ADDONS_MODULES_LIST, Tools::addonsRequest('addons-modules'))) {
+                    $status = 'refresh';
+                } else {
+                    $status = 'error';
+                }
+            } else {
+                $status = 'cache';
+            }
+        }
+
+        if ($status != 'error') {
+            if (!Tools::isFresh(Module::CACHE_FILE_TAB_MODULES_LIST, _TIME_1_WEEK_)) {
+                if (Tools::refresh(Module::CACHE_FILE_TAB_MODULES_LIST, _QLO_TAB_MODULE_LIST_URL_)) {
+                    $status = 'refresh';
+                } else {
+                    $status = 'error';
+                }
+            } else {
+                $status = 'cache';
+            }
         }
 
         return $status;

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -206,16 +206,6 @@ class AdminModulesControllerCore extends AdminController
             } else {
                 $this->status = 'cache';
             }
-
-            if (!Tools::isFresh(Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, _TIME_1_DAY_) || $force_reload_cache) {
-                if (file_put_contents(_PS_ROOT_DIR_.Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, Tools::addonsRequest('must-have'))) {
-                    $this->status = 'refresh';
-                } else {
-                    $this->status = 'error';
-                }
-            } else {
-                $this->status = 'cache';
-            }
         }
 
         // If logged to Addons Webservices, refresh customer modules list every 5 minutes
@@ -736,7 +726,10 @@ class AdminModulesControllerCore extends AdminController
                 return;
             }
 
-            if ($key == 'checkAndUpdate') {
+            if ($key == 'check') {
+                $this->ajaxProcessRefreshModuleList(true);
+            } elseif ($key == 'checkAndUpdate') {
+                $this->ajaxProcessRefreshModuleList(true);
                 $modules = array();
                 $modules_on_disk = Module::getModulesOnDisk(true, $this->logged_on_addons, $this->id_employee, true);
 


### PR DESCRIPTION
Unable to check for update and download module error was showing on the manage module page when checking for module updates.
