### PR TITLE
Fixed: totalAvailableRooms warning issue resolved on room detail page

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -603,6 +603,7 @@ class ProductControllerCore extends FrontController
             $quantity = 1;
         }
 
+        $totalAvailableRooms = 0;
         if ($hotelRoomData = $objBookingDetail->DataForFrontSearch($bookingParams)) {
             $totalAvailableRooms = $hotelRoomData['stats']['num_avail'];
             $quantity = ($quantity > $totalAvailableRooms) ? $totalAvailableRooms : $quantity;


### PR DESCRIPTION
Fixed: totalAvailableRooms warning issue on the room details page if there are no rooms in the room type.