### PR TITLE
Resolved: Backoffice ajax loader does not stop after closing dashboard recommendation

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1616,7 +1616,7 @@ function loadRecommendation()
 			token: token
 		},
 		success: function(res) {
-			if (res.success && res.content.trim()) {
+			if (res.success && res.content && res.content.trim()) {
 				$('#recommendation-wrapper-skeleton').fadeIn('slow');
 				$('#recommendation-wrapper').html(res.content);
 				let images = $('#recommendation-wrapper img');


### PR DESCRIPTION
After closing back office dashboard recommendation block, the ajax loader on the navbar does not stop spinning.