### PR TITLE
Resolved: Unable to add room in cart from front and backoffice

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -362,11 +362,11 @@ abstract class PaymentModuleCore extends Module
                         $order->with_occupancy = 0;
                     } else {
                         if (defined('_PS_ADMIN_DIR_')) {
-                            if (Configuration::get('PS_BACKOFFICE_ROOM_BOOKING_TYPE') == HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
+                            if (Configuration::get('PS_BACKOFFICE_ROOM_BOOKING_TYPE') == HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
                                 $order->with_occupancy = 1;
                             }
                         } else {
-                            if (Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE') == HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
+                            if (Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE') == HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
                                 $order->with_occupancy = 1;
                             }
                         }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -441,7 +441,7 @@ class FrontControllerCore extends Controller
         }
 
         $occupancyRequiredForBooking = false;
-        if (Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE') == HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
+        if (Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE') == HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
             $occupancyRequiredForBooking = true;
         }
         $this->context->smarty->assign(array(

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -252,7 +252,7 @@ class AdminOrdersControllerCore extends AdminController
         }
 
         $occupancyRequiredForBooking = false;
-        if (Configuration::get('PS_BACKOFFICE_ROOM_BOOKING_TYPE') == HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
+        if (Configuration::get('PS_BACKOFFICE_ROOM_BOOKING_TYPE') == HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
             $occupancyRequiredForBooking = true;
         }
 

--- a/controllers/admin/AdminPPreferencesController.php
+++ b/controllers/admin/AdminPPreferencesController.php
@@ -146,8 +146,8 @@ class AdminPPreferencesControllerCore extends AdminController
                         'cast' => 'intval',
                         'type' => 'select',
                         'list' => array(
-                            array('id' => HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY, 'name' => $this->l('Room Occupancy')),
-                            array('id' => HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_QUANTITY, 'name' => $this->l('Rooms Quantity (No. of rooms)'))
+                            array('id' => HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY, 'name' => $this->l('Room Occupancy')),
+                            array('id' => HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_QUANTITY, 'name' => $this->l('Rooms Quantity (No. of rooms)'))
                         ),
                         'identifier' => 'id',
                     ),
@@ -181,8 +181,8 @@ class AdminPPreferencesControllerCore extends AdminController
                         'cast' => 'intval',
                         'type' => 'select',
                         'list' => array(
-                            array('id' => HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY, 'name' => $this->l('Room Occupancy')),
-                            array('id' => HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_QUANTITY, 'name' => $this->l('Rooms Quantity (No. of rooms)'))
+                            array('id' => HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY, 'name' => $this->l('Room Occupancy')),
+                            array('id' => HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_QUANTITY, 'name' => $this->l('Rooms Quantity (No. of rooms)'))
                         ),
                         'identifier' => 'id',
                     ),
@@ -442,11 +442,11 @@ class AdminPPreferencesControllerCore extends AdminController
         }
 
         if (Tools::getValue('PS_FRONT_SEARCH_TYPE') == HotelBookingDetail::SEARCH_TYPE_OWS) {
-            $_POST['PS_FRONT_ROOM_UNIT_SELECTION_TYPE'] = HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY;
+            $_POST['PS_FRONT_ROOM_UNIT_SELECTION_TYPE'] = HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY;
         }
 
         if (Tools::getValue('PS_BACKOFFICE_SEARCH_TYPE') == HotelBookingDetail::SEARCH_TYPE_OWS) {
-            $_POST['PS_BACKOFFICE_ROOM_BOOKING_TYPE'] = HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY;
+            $_POST['PS_BACKOFFICE_ROOM_BOOKING_TYPE'] = HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY;
         }
 
         if (Tools::getIsset('PS_CATALOG_MODE')) {

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -285,11 +285,11 @@ class CartControllerCore extends FrontController
 
         if ($product->booking_product) {
             $occupancyRequiredForBooking = false;
-            if (Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE') == HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
+            if (Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE') == HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
                 $occupancyRequiredForBooking = true;
             }
 
-            if ($occupancyRequiredForBooking) {
+            if ($occupancyRequiredForBooking && $operator == 'up') {
                 if ($occupancy = json_decode(Tools::getValue('occupancy'), true)) {
                     $this->qty = count($occupancy);
                 } else {

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -591,7 +591,7 @@ class ProductControllerCore extends FrontController
             'id_cart' => $idCart,
             'id_guest' => $idGuest,
         );
-        if (Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE') == HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
+        if (Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE') == HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
             $bookingParams['occupancy'] = $occupancy;
             $quantity = count($occupancy);
         } else {

--- a/modules/hotelreservationsystem/classes/HotelBookingDetail.php
+++ b/modules/hotelreservationsystem/classes/HotelBookingDetail.php
@@ -82,8 +82,8 @@ class HotelBookingDetail extends ObjectModel
     const SEARCH_TYPE_NORMAL = 2;
 
     //
-    const PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY = 1;
-    const PS_FRONT_ROOM_UNIT_SELECTION_TYPE_QUANTITY = 2;
+    const PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY = 1;
+    const PS_ROOM_UNIT_SELECTION_TYPE_QUANTITY = 2;
 
     public static $definition = array(
         'table' => 'htl_booking_detail',

--- a/modules/hotelreservationsystem/classes/HotelCartBookingData.php
+++ b/modules/hotelreservationsystem/classes/HotelCartBookingData.php
@@ -450,7 +450,12 @@ class HotelCartBookingData extends ObjectModel
         $chkQty = 0;
         $num_days = HotelHelper::getNumberOfDays($date_from, $date_to);
         $objRoomTypeServiceProductCartDetail = new RoomTypeServiceProductCartDetail();
-        if (Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE') == HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
+        if (defined('_PS_ADMIN_DIR_')) {
+            $PS_ROOM_UNIT_SELECTION_TYPE = Configuration::get('PS_BACKOFFICE_ROOM_BOOKING_TYPE');
+        } else {
+            $PS_ROOM_UNIT_SELECTION_TYPE = Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE');
+        }
+        if ($PS_ROOM_UNIT_SELECTION_TYPE == HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
             $roomsRequired = count($occupancy);
         } else {
             $objRoomType = new HotelRoomType();
@@ -475,7 +480,7 @@ class HotelCartBookingData extends ObjectModel
                     $obj_htl_cart_booking_data->extra_demands = $roomDemand;
                     $obj_htl_cart_booking_data->date_from = $date_from;
                     $obj_htl_cart_booking_data->date_to = $date_to;
-                    if (Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE') == HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
+                    if ($PS_ROOM_UNIT_SELECTION_TYPE == HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
                         $room_occupancy = array_shift($occupancy);
                         $obj_htl_cart_booking_data->adults = $room_occupancy['adults'];
                         $obj_htl_cart_booking_data->children = $room_occupancy['children'];
@@ -573,8 +578,12 @@ class HotelCartBookingData extends ObjectModel
                 'id_cart' => $id_cart,
                 'id_guest' => $id_guest,
             );
-
-            if (Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE') == HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
+            if (defined('_PS_ADMIN_DIR_')) {
+                $PS_ROOM_UNIT_SELECTION_TYPE = Configuration::get('PS_BACKOFFICE_ROOM_BOOKING_TYPE');
+            } else {
+                $PS_ROOM_UNIT_SELECTION_TYPE = Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE');
+            }
+            if ($PS_ROOM_UNIT_SELECTION_TYPE == HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
                 $roomsRequired = count($occupancy);
             } else {
                 $roomsRequired = $occupancy;

--- a/modules/hotelreservationsystem/classes/HotelHelper.php
+++ b/modules/hotelreservationsystem/classes/HotelHelper.php
@@ -256,10 +256,10 @@ class HotelHelper
         // Search Fields
         Configuration::updateValue('PS_FRONT_SEARCH_TYPE', HotelBookingDetail::SEARCH_TYPE_OWS);
         Configuration::updateValue('PS_FRONT_OWS_SEARCH_ALGO_TYPE', HotelBookingDetail::SEARCH_EXACT_ROOM_TYPE_ALGO);
-        Configuration::updateValue('PS_FRONT_ROOM_UNIT_SELECTION_TYPE', HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY);
+        Configuration::updateValue('PS_FRONT_ROOM_UNIT_SELECTION_TYPE', HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY);
         Configuration::updateValue('PS_BACKOFFICE_SEARCH_TYPE', HotelBookingDetail::SEARCH_TYPE_OWS);
         Configuration::updateValue('PS_BACKOFFICE_OWS_SEARCH_ALGO_TYPE', HotelBookingDetail::SEARCH_ALL_ROOM_TYPE_ALGO);
-        Configuration::updateValue('PS_BACKOFFICE_ROOM_BOOKING_TYPE', HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY);
+        Configuration::updateValue('PS_BACKOFFICE_ROOM_BOOKING_TYPE', HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY);
 
         return true;
     }

--- a/modules/hotelreservationsystem/controllers/admin/AdminHotelRoomsBookingController.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminHotelRoomsBookingController.php
@@ -300,7 +300,7 @@ class AdminHotelRoomsBookingController extends ModuleAdminController
 
         $allotmentTypes = HotelBookingDetail::getAllAllotmentTypes();
         $occupancyRequiredForBooking = false;
-        if (Configuration::get('PS_BACKOFFICE_ROOM_BOOKING_TYPE') == HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
+        if (Configuration::get('PS_BACKOFFICE_ROOM_BOOKING_TYPE') == HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
             $occupancyRequiredForBooking = true;
         }
 
@@ -765,7 +765,7 @@ class AdminHotelRoomsBookingController extends ModuleAdminController
         parent::setMedia();
         $currency = new Currency((int)Configuration::get('PS_CURRENCY_DEFAULT'));
         $occupancyRequiredForBooking = false;
-        if (Configuration::get('PS_BACKOFFICE_ROOM_BOOKING_TYPE') == HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
+        if (Configuration::get('PS_BACKOFFICE_ROOM_BOOKING_TYPE') == HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
             $occupancyRequiredForBooking = true;
         }
         $jsVars = array(

--- a/modules/hotelreservationsystem/views/js/admin/hotel_rooms_booking.js
+++ b/modules/hotelreservationsystem/views/js/admin/hotel_rooms_booking.js
@@ -312,7 +312,7 @@ $(document).ready(function() {
                 occupancy = false;
             }
         } else {
-            return true;
+            return 1;
         }
 
         return occupancy;

--- a/modules/wkroomsearchblock/wkroomsearchblock.php
+++ b/modules/wkroomsearchblock/wkroomsearchblock.php
@@ -168,7 +168,7 @@ class WkRoomSearchBlock extends Module
         $maxOrderDate = Tools::getValue('max_order_date');
         $maxOrderDate = date('Y-m-d', strtotime($maxOrderDate));
 
-        if (Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE') == HotelBookingDetail::PS_FRONT_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
+        if (Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE') == HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_OCCUPANCY) {
             if ($occupancy = Tools::getValue('occupancy')) {
                 $urlData['occupancy'] = $occupancy;
             }


### PR DESCRIPTION
Resolves issues while adding or removing rooms from the cart when occupancy-wise search is disabled and rooms are added to the cart with quantity.