### PR TITLE
Resolved: Catalog discount is not visible when auto add service is attached to room type

### DIFF
--- a/modules/hotelreservationsystem/classes/HotelBookingDetail.php
+++ b/modules/hotelreservationsystem/classes/HotelBookingDetail.php
@@ -1541,6 +1541,7 @@ class HotelBookingDetail extends ObjectModel
                             $prod_price = Product::getPriceStatic($value['id_product'], self::useTax());
                             $productPriceWithoutReduction = $product->getPriceWithoutReduct(!self::useTax());
                             $productFeaturePrice = HotelRoomTypeFeaturePricing::getRoomTypeFeaturePricesPerDay($value['id_product'], $date_from, $date_to, self::useTax());
+                            $productFeaturePriceWithoutAutoAdd = HotelRoomTypeFeaturePricing::getRoomTypeFeaturePricesPerDay($value['id_product'], $date_from, $date_to, self::useTax(), 0, 0, 0, 0, 0);
 
                             if (empty($price) || ($price['from'] <= $prod_price && $price['to'] >= $prod_price)) {
                                 $cover_image_arr = $product->getCover($value['id_product']);
@@ -1560,9 +1561,11 @@ class HotelBookingDetail extends ObjectModel
                                 $bookingData['rm_data'][$key]['description'] = $product->description_short;
                                 $bookingData['rm_data'][$key]['feature'] = $product_feature;
                                 $bookingData['rm_data'][$key]['price'] = $prod_price;
-                                $bookingData['rm_data'][$key]['price_without_reduction'] = $productPriceWithoutReduction;
                                 $bookingData['rm_data'][$key]['feature_price'] = $productFeaturePrice;
-                                $bookingData['rm_data'][$key]['feature_price_diff'] = $productPriceWithoutReduction - $productFeaturePrice;
+                                $bookingData['rm_data'][$key]['feature_price_withoout_auto_add'] = $productFeaturePriceWithoutAutoAdd;
+                                $bookingData['rm_data'][$key]['price_without_reduction'] = $productPriceWithoutReduction;
+                                $bookingData['rm_data'][$key]['price_without_reduction_with_auto_add'] = $productPriceWithoutReduction + ($productFeaturePrice - $productFeaturePriceWithoutAutoAdd);
+                                $bookingData['rm_data'][$key]['feature_price_diff'] = $bookingData['rm_data'][$key]['price_without_reduction_with_auto_add'] - $productFeaturePrice;
 
                                 // if ($room_left <= (int)Configuration::get('WK_ROOM_LEFT_WARNING_NUMBER'))
                                 $bookingData['rm_data'][$key]['room_left'] = $room_left;

--- a/themes/hotel-reservation-theme/_partials/room_type_list.tpl
+++ b/themes/hotel-reservation-theme/_partials/room_type_list.tpl
@@ -57,7 +57,7 @@
 									<p class="rm_price_cont">
 										{if $room_v['feature_price_diff'] >= 0}
 											<span class="rm_price_val {if $room_v['feature_price_diff']>0}room_type_old_price{/if}">
-												{displayPrice price = $room_v['price_without_reduction']|round:2|floatVal}
+												{displayPrice price = $room_v['price_without_reduction_with_auto_add']|round:2|floatVal}
 											</span>
 										{/if}
 										{if $room_v['feature_price_diff']}


### PR DESCRIPTION
When an auto add service is added to room type, catalog discount is not visible if final price is greater than the room price without reduction. 
Added service price in room price without reduction.