### PR TITLE
Added: Primary hotel in QloApps for tax calculation of service products

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3036,9 +3036,6 @@ class CartCore extends ObjectModel
         } else if ($id_hotel) {
             $addressInfo = HotelBranchInformation::getAddress($id_hotel);
             return $addressInfo['id_address'];
-        } else {
-            // provide an address for service product.
-            // for now we do not have an address associated with the service product
         }
         return false;
     }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3036,6 +3036,9 @@ class CartCore extends ObjectModel
         } else if ($id_hotel) {
             $addressInfo = HotelBranchInformation::getAddress($id_hotel);
             return $addressInfo['id_address'];
+        } else {
+            // provide an address for service product.
+            // for now we do not have an address associated with the service product
         }
         return false;
     }

--- a/modules/hotelreservationsystem/classes/HotelHelper.php
+++ b/modules/hotelreservationsystem/classes/HotelHelper.php
@@ -401,6 +401,8 @@ class HotelHelper
             $obj_hotel_info->id_category = $cat_hotel;
             $obj_hotel_info->save();
         }
+        // save dummy hotel as primary hotel
+        Configuration::updateValue('WK_PRIMARY_HOTEL', $htl_id);
 
         return $htl_id;
     }

--- a/modules/hotelreservationsystem/controllers/admin/AdminAddHotelController.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminAddHotelController.php
@@ -422,6 +422,18 @@ class AdminAddHotelController extends ModuleAdminController
 
             if ($newIdHotel = $objHotelBranch->id) {
 
+                if ($primaryHotelId = Configuration::get('WK_PRIMARY_HOTEL')) {
+                    if ($primaryHotelId == $objHotelBranch->id && !$objHotelBranch->active) {
+                        $hotels = $objHotelBranch->hotelBranchesInfo(false, 1);
+                        if (!empty($hotel = array_shift($hotels))) {
+                            Configuration::updateValue('WK_PRIMARY_HOTEL', $objHotelBranch['id']);
+                        } else {
+                            $newPrimaryHotelId = Configuration::updateValue('WK_PRIMARY_HOTEL', 0);
+                        }
+                    }
+                } else if ($objHotelBranch->active) {
+                    Configuration::updateValue('WK_PRIMARY_HOTEL', $objHotelBranch->id);
+                }
                 // getHotel address
                 if ($idHotelAddress = $objHotelBranch->getHotelIdAddress()) {
                 $objAddress = new Address($idHotelAddress);
@@ -559,6 +571,29 @@ class AdminAddHotelController extends ModuleAdminController
             $this->display = 'add';
         }
     }
+    public function processStatus()
+    {
+        parent::processStatus();
+        if (empty($this->errors)) {
+            if (Validate::isLoadedObject($objHotelBranch = new HotelBranchInformation(Tools::getValue('id')))) {
+                if ($primaryHotelId = Configuration::get('WK_PRIMARY_HOTEL')) {
+                    if ($primaryHotelId == $objHotelBranch->id && !$objHotelBranch->active) {
+                        $hotels = $objHotelBranch->hotelBranchesInfo(false, 1);
+                        if (!empty($hotel = array_shift($hotels))) {
+                            Configuration::updateValue('WK_PRIMARY_HOTEL', $hotel['id']);
+                        } else {
+                            $newPrimaryHotelId = Configuration::updateValue('WK_PRIMARY_HOTEL', 0);
+                        }
+                    }
+                } else {
+                    $hotels = $objHotelBranch->hotelBranchesInfo(false, 1);
+                    if (!empty($hotel = array_shift($hotels))) {
+                        Configuration::updateValue('WK_PRIMARY_HOTEL', $hotel['id']);
+                    }
+                }
+            }
+        }
+    }
 
     public function ajaxProcessStateByCountryId()
     {
@@ -686,6 +721,8 @@ class AdminAddHotelController extends ModuleAdminController
                 'filesizeError' => $this->l('File exceeds maximum size.'),
                 'maxSizeAllowed' => Tools::getMaxUploadSize(),
                 'sortRowsUrl' => $this->context->link->getAdminLink('AdminAddHotel'),
+                'primaryHotelId' => Configuration::get('WK_PRIMARY_HOTEL'),
+                'disableHotelMsg' => $this->l('Primary hotel for website will be updated to first available active hotel.'),
             )
         );
         // GOOGLE MAP

--- a/modules/hotelreservationsystem/controllers/admin/AdminHotelGeneralSettingsController.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminHotelGeneralSettingsController.php
@@ -35,6 +35,9 @@ class AdminHotelGeneralSettingsController extends ModuleAdminController
         if (!$hotelsInfo = $objHotelInfo->hotelBranchesInfo(false, 1)) {
             $hotelsInfo = array();
         }
+        foreach ($hotelsInfo as &$hotel) {
+            $hotel['name'] = $hotel['hotel_name'];
+        }
         $hotelNameDisable = (count($hotelsInfo) > 1 ? true : false);
         $locationDisable = ((count($hotelsInfo) < 2) && !Configuration::get('WK_HOTEL_NAME_ENABLE')) ? true : false;
         $this->fields_options = array(
@@ -141,6 +144,13 @@ class AdminHotelGeneralSettingsController extends ModuleAdminController
                         'title' => $this->l('Website Launch Year'),
                         'hint' => $this->l('The year when your hotel site was launched.'),
                         'type' => 'text',
+                    ),
+                    'WK_PRIMARY_HOTEL' => array(
+                        'title' => $this->l('Primary hotel'),
+                        'hint' => $this->l('Primary hotel is used to default address for your business. The hotel address will be considered as your registered business address.'),
+                        'type' => 'select',
+                        'identifier' => 'id',
+                        'list' => $hotelsInfo,
                     ),
                     'WK_HTL_CHAIN_NAME' => array(
                         'title' => $this->l('Hotel Name'),

--- a/modules/hotelreservationsystem/views/js/HotelReservationAdmin.js
+++ b/modules/hotelreservationsystem/views/js/HotelReservationAdmin.js
@@ -227,6 +227,30 @@ function initGoogleMaps() {
 
 $(document).ready(function() {
     //For Add Hotels
+
+    // hotel status change
+    $("#form-htl_branch_info a.list-action-enable.action-enabled").on('click', function(e) {
+        let id_hotel = $(this).closest('tr').find('.row-selector input').val();
+        if (id_hotel == primaryHotelId) {
+            if (!confirm(disableHotelMsg)) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                return false;
+            }
+        }
+    });
+    $("form#htl_branch_info_form").on('submit', function(e) {
+        let id_hotel = $(this).find('#id-hotel').val();
+        let enable = $(this).find('[name="ENABLE_HOTEL"]:checked').val();
+        if (id_hotel == primaryHotelId && !parseInt(enable)) {
+            if (!confirm(disableHotelMsg)) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                return false;
+            }
+        }
+    });
+
     // delete hotel image
 	$('.deleteHtlImage').on('click', function(){
 		var imgId = $(this).attr('id_htl_img');


### PR DESCRIPTION
Now in QloApps, added an option to select a primary hotel (main branch) for the hotel branch. 
This hotel will be used for tax calculation for any service or product that is not attached to the hotel or room type. 