### PR TITLE
Fix: Dropdown displaces on search result page when adding children in room

### DIFF
--- a/themes/hotel-reservation-theme/css/category.css
+++ b/themes/hotel-reservation-theme/css/category.css
@@ -254,6 +254,9 @@ p.capa_txt {
 .booking_guest_occupancy_conatiner {
     display: flex;
 }
+.booking_guest_occupancy_conatiner .booking_occupancy_wrapper {
+    left: unset;
+}
 @media (min-width: 992px) {
     .room_features_cont > div {
         display: flex;


### PR DESCRIPTION
When adding children to the room dropdown gets displaced to left on the search result page.