### PR TITLE
Fixed: book now page calender does not show searched date month

### DIFF
--- a/modules/hotelreservationsystem/controllers/admin/AdminHotelRoomsBookingController.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminHotelRoomsBookingController.php
@@ -260,6 +260,10 @@ class AdminHotelRoomsBookingController extends ModuleAdminController
             'booking_product' => $this->booking_product,
             'is_occupancy_wise_search' => $isOccupancyWiseSearch,
         ));
+        MediaCore::addJsDef(array(
+            'initialDate' => $this->date_from
+        ));
+
     }
 
     public function renderView()

--- a/modules/hotelreservationsystem/views/js/admin/hotel_rooms_booking.js
+++ b/modules/hotelreservationsystem/views/js/admin/hotel_rooms_booking.js
@@ -23,6 +23,7 @@ $(document).ready(function() {
     if ($('#fullcalendar').length) {
         var calendar = new FullCalendar.Calendar($('#fullcalendar').get(0), {
             initialView: 'dayGridMonth',
+            initialDate: initialDate,
             events: {
                 url: rooms_booking_url,
                 method: 'POST',


### PR DESCRIPTION
When searching rooms for the next or previous month on the book now page, the calender still loads the current month.