### PR TITLE
Update refund request view page at back office

### DIFF
--- a/modules/hotelreservationsystem/views/js/admin/wk_refund_request.js
+++ b/modules/hotelreservationsystem/views/js/admin/wk_refund_request.js
@@ -49,4 +49,34 @@ $(document).ready(function() {
 		}
         $('#generateCreditSlip').change();
 	});
+
+    $(document).on('keyup', '#order_return_form .table input[name^="refund_amounts"]', function() {
+        let refundAmountInputs = $('#order_return_form .table input[name^="refund_amounts"]');
+
+        let disableRefundOptions = false;
+        $(refundAmountInputs).each(function(index, element) {
+            let val = parseFloat($(element).val().trim());
+            if (isNaN(val)) { // if at least one amount input is empty
+                disableRefundOptions = true;
+                return;
+            }
+        });
+
+        if (!disableRefundOptions) {
+            let hasAllZero = true;
+            $(refundAmountInputs).each(function(index, element) {
+                let val = parseFloat($(element).val().trim());
+                if (val != 0) {
+                    hasAllZero = false;
+                    return;
+                }
+            });
+
+            if (hasAllZero) { // if all amount inputs are 0
+                disableRefundOptions = true;
+            }
+        }
+
+        $('#generateCreditSlip, #refundTransactionAmount, #generateDiscount').attr('disabled', disableRefundOptions);
+    });
 });

--- a/modules/hotelreservationsystem/views/templates/admin/order_refund_requests/helpers/view/view.tpl
+++ b/modules/hotelreservationsystem/views/templates/admin/order_refund_requests/helpers/view/view.tpl
@@ -148,7 +148,7 @@
 																{displayPrice price=$booking['refunded_amount'] currency=$orderCurrency['id']}
 															{else}
 																<span class="input-group-addon">{$orderCurrency['sign']|escape:'html':'UTF-8'}</span>
-																<input placeholder="" type="text" name="refund_amounts[{$booking['id_order_return_detail']|escape:'html':'UTF-8'}]">
+																<input placeholder="" type="text" name="refund_amounts[{$booking['id_order_return_detail']|escape:'html':'UTF-8'}]" value="{$booking['total_paid_amount'] - $booking['cancelation_charge']}">
 																<span class="input-group-addon">{l s='tax incl.' mod='hotelreservationsystem'}</span>
 															{/if}
 														</div>


### PR DESCRIPTION
This PR allows makes following changes:
1. Allows admin to see refund amount pre-filled when viewing refund detail at back office.
2. Update refund options if refund amount is zero.