### PR TITLE
Change refund rule text from 'Days before cancellation' to 'Days before check-in' at back office

### DIFF
--- a/modules/hotelreservationsystem/controllers/admin/AdminOrderRefundRulesController.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminOrderRefundRulesController.php
@@ -87,7 +87,7 @@ class AdminOrderRefundRulesController extends ModuleAdminController
                 'callback' => 'setOrderCurrency',
             ),
             'days' => array(
-                'title' => $this->l('Days'),
+                'title' => $this->l('Days Before Check-in'),
                 'align' => 'center',
             )
         );

--- a/modules/hotelreservationsystem/views/templates/admin/add_hotel/helpers/form/form.tpl
+++ b/modules/hotelreservationsystem/views/templates/admin/add_hotel/helpers/form/form.tpl
@@ -398,7 +398,7 @@
 												<th>{l s='Name' mod='hotelreservationsystem'}</th>
 												<th>{l s='Full payment charges' mod='hotelreservationsystem'}</th>
 												<th>{l s='Advance payment charges' mod='hotelreservationsystem'}</th>
-												<th>{l s='Days before cancelation' mod='hotelreservationsystem'}</th>
+												<th>{l s='Days before check-in' mod='hotelreservationsystem'}</th>
 											</tr>
 										</thead>
 										<tbody id="slides">

--- a/modules/hotelreservationsystem/views/templates/admin/order_refund_rules/helpers/form/form.tpl
+++ b/modules/hotelreservationsystem/views/templates/admin/order_refund_rules/helpers/form/form.tpl
@@ -113,7 +113,7 @@
 
 		<div class="form-group">
 			<label for="cancelation_days" class="required control-label col-lg-3">
-				<span title="" data-toggle="tooltip" class="label-tooltip" data-original-title='{l s="Enter number of days before check-in date for this rule to be applicable." mod="hotelreservationsyatem"}'>{l s='Days before cancellation' mod="hotelreservationsyatem"}</span>
+				<span title="" data-toggle="tooltip" class="label-tooltip" data-original-title='{l s="Enter number of days before check-in date for this rule to be applicable." mod="hotelreservationsyatem"}'>{l s='Days before check-in' mod="hotelreservationsyatem"}</span>
 			</label>
 			<div class="col-lg-2">
 				<input class="form-control" type="text" id="cancelation_days" name="cancelation_days" {if isset($edit)} {if isset($refund_rules_info['days'])}style = "display:block;" value="{$refund_rules_info['days']}" {/if}{/if}>


### PR DESCRIPTION
Change refund rule text from 'Days before cancellation' to 'Days before check-in' at back office wherever applicable.