### PR TITLE
Fix: Occupancy panel does not close when clicking on add to cart button

### DIFF
--- a/modules/blockcart/ajax-cart.js
+++ b/modules/blockcart/ajax-cart.js
@@ -1287,6 +1287,7 @@ function getBookingOccupancyDetails(bookingform)
 {
     let occupancy;
     if (occupancy_required_for_booking) {
+        $('.booking_guest_occupancy_conatiner .dropdown').removeClass('open');
         let selected_occupancy = $(bookingform).find(".occupancy_info_block.selected")
         if (selected_occupancy.length) {
             occupancy = [];
@@ -1302,7 +1303,6 @@ function getBookingOccupancyDetails(bookingform)
                         if (child_ages.length != $(element).find('.num_children').val()) {
                             $(bookingform).find('.booking_occupancy_wrapper').parent().addClass('open')
                             occupancy = false;
-                            return false;
                         }
                     }
                     occupancy.push({
@@ -1313,7 +1313,6 @@ function getBookingOccupancyDetails(bookingform)
                 } else {
                     $(bookingform).find('.booking_occupancy_wrapper').parent().addClass('open')
                     occupancy = false;
-                    return false;
                 }
             });
         } else {

--- a/modules/hotelreservationsystem/views/js/admin/hotel_rooms_booking.js
+++ b/modules/hotelreservationsystem/views/js/admin/hotel_rooms_booking.js
@@ -279,6 +279,7 @@ $(document).ready(function() {
     {
         let occupancy;
         if (occupancy_required_for_booking) {
+            $('.booking_occupancy_wrapper').parent().removeClass('open');
             let selected_occupancy = $(bookingform).find(".occupancy_info_block.selected")
             if (selected_occupancy.length) {
                 occupancy = [];
@@ -305,7 +306,6 @@ $(document).ready(function() {
                     } else {
                         $(bookingform).find('.booking_occupancy_wrapper').parent().addClass('open');
                         occupancy = false;
-                        return false;
                     }
                 });
             } else {

--- a/themes/hotel-reservation-theme/js/modules/blockcart/ajax-cart.js
+++ b/themes/hotel-reservation-theme/js/modules/blockcart/ajax-cart.js
@@ -1054,7 +1054,6 @@ var ajaxCart = {
     },
 
     updateLayer: function(product) {
-        console.log(product);
         // change text labels according to product type
         $('#layer_cart .layer_cart_room_txt').hide();
         $('#layer_cart .layer_cart_product_txt').hide();
@@ -1288,6 +1287,7 @@ function getBookingOccupancyDetails(bookingform)
 {
     let occupancy;
     if (occupancy_required_for_booking) {
+        $('.booking_guest_occupancy_conatiner .dropdown').removeClass('open');
         let selected_occupancy = $(bookingform).find(".occupancy_info_block.selected")
         if (selected_occupancy.length) {
             occupancy = [];
@@ -1310,9 +1310,6 @@ function getBookingOccupancyDetails(bookingform)
                         'children': $(element).find('.num_children').val(),
                         'child_ages': child_ages
                     });
-                    if ($(bookingform).find('.booking_occupancy_wrapper').parent().hasClass('open')) {
-                        $('.booking_guest_occupancy_conatiner .dropdown').removeClass('open');
-                    }
                 } else {
                     $(bookingform).find('.booking_occupancy_wrapper').parent().addClass('open')
                     occupancy = false;


### PR DESCRIPTION
Occupancy panel does not get closed when clicking on add to cart button in admin book now page and search result page
This issue occurs when a occupancy select panel is open and click on add to cart button for some different room