### PR TITLE
Fix: imgaes index not defined for services on room type page in front office 

### DIFF
--- a/modules/hotelreservationsystem/classes/RoomTypeServiceProduct.php
+++ b/modules/hotelreservationsystem/classes/RoomTypeServiceProduct.php
@@ -182,8 +182,8 @@ class RoomTypeServiceProduct extends ObjectModel
                     1,
                     $useTax
                 );
+                $serviceProduct['images'] = Image::getImages((int)Context::getContext()->language->id, $serviceProduct['id_product']);
             }
-            $serviceProduct['images'] = Image::getImages((int)Context::getContext()->language->id, $serviceProduct['id_product']);
         }
 
         return $serviceProducts;


### PR DESCRIPTION
When added more than one service, images index does not get defined for services other than last service