### PR TITLE
Fix: Booking form does not get update when occupancy is not  provided

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1218,6 +1218,9 @@ class ProductControllerCore extends FrontController
 
         $dateFrom = date('Y-m-d', strtotime($dateFrom));
         $dateTo = date('Y-m-d', strtotime($dateTo));
+        if ($occupancy == false) {
+            $occupancy = array();
+        }
         $this->assignServiceProductVars();
         if ($this->assignBookingFormVars(
             $idProduct,


### PR DESCRIPTION
When adding any service or changing the date without updating occupancy, the booking form does not get updated.