### PR TITLE
Fix: Booking form refresh when occupancy dropdown is opened

### DIFF
--- a/themes/hotel-reservation-theme/js/occupancy.js
+++ b/themes/hotel-reservation-theme/js/occupancy.js
@@ -181,8 +181,8 @@ $(document).ready(function(){
                     )) {
                         $(occupancy_wrapper).parent().removeClass('open');
                         $(occupancy_wrapper).siblings(".booking_guest_occupancy").removeClass('error_border');
+                        $(document).trigger( "QloApps:updateRoomOccupancy", [occupancy_wrapper]);
                     }
-                    $(document).trigger( "QloApps:updateRoomOccupancy", [occupancy_wrapper]);
                 } else {
                     $(occupancy_wrapper).siblings(".booking_guest_occupancy").addClass('error_border');
                 }


### PR DESCRIPTION
When the occupancy dropdown is opened by clicking the book now button on the room type page, the booking form gets refreshed and causes the occupancy dropdown to close.