### PR TITLE
Allow checkout process classes to be overridden

### DIFF
--- a/classes/checkoutProcess/AbstractCheckoutStep.php
+++ b/classes/checkoutProcess/AbstractCheckoutStep.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-abstract class AbstractCheckoutStep implements CheckoutStepInterface
+abstract class AbstractCheckoutStepCore implements CheckoutStepInterface
 {
     public $step_is_reachable = 0;
     public $step_is_complete = 0;

--- a/classes/checkoutProcess/CheckoutCartSummaryStep.php
+++ b/classes/checkoutProcess/CheckoutCartSummaryStep.php
@@ -18,7 +18,7 @@
 *  @license   https://store.webkul.com/license.html
 */
 
-class CheckoutCartSummaryStep extends AbstractCheckoutStep
+class CheckoutCartSummaryStepCore extends AbstractCheckoutStepCore
 {
     public function __construct()
     {

--- a/classes/checkoutProcess/CheckoutCustomerDetailsStep.php
+++ b/classes/checkoutProcess/CheckoutCustomerDetailsStep.php
@@ -18,7 +18,7 @@
 *  @license   https://store.webkul.com/license.html
 */
 
-class CheckoutCustomerDetailsStep extends AbstractCheckoutStep
+class CheckoutCustomerDetailsStepCore extends AbstractCheckoutStepCore
 {
     public function __construct()
     {

--- a/classes/checkoutProcess/CheckoutPaymentStep.php
+++ b/classes/checkoutProcess/CheckoutPaymentStep.php
@@ -18,7 +18,7 @@
 *  @license   https://store.webkul.com/license.html
 */
 
-class CheckoutPaymentStep extends AbstractCheckoutStep
+class CheckoutPaymentStepCore extends AbstractCheckoutStepCore
 {
     public function __construct() {
         parent::__construct();

--- a/classes/checkoutProcess/CheckoutProcess.php
+++ b/classes/checkoutProcess/CheckoutProcess.php
@@ -18,7 +18,7 @@
 *  @license   https://store.webkul.com/license.html
 */
 
-class CheckoutProcess
+class CheckoutProcessCore
 {
     public $steps = array();
 


### PR DESCRIPTION
This PR allows following checkout process classes to be overridden:
- CheckoutProcess.php
- AbstractCheckoutStep.php
- CheckoutCartSummaryStep.php
- CheckoutCustomerDetailsStep.php
- CheckoutPaymentStep.php