### PR TITLE
Fix: Module update error when uploading zip without db changes

### DIFF
--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -1836,7 +1836,9 @@ class AdminModulesControllerCore extends AdminController
                             $this->errors[] = $this->l('Module not found!');
                         }
                     } else {
-                        $this->errors[] = $this->l('There was some error while updating the module');
+                        $response['success'] = true;
+                        $response['msg'] = $this->l('Module files updated successfully');
+                        $response['data']['redirect'] = $this->context->link->getAdminLink('AdminModules').'&conf=29&anchor='.$module->name;
                     }
                 } else {
                     $this->errors[] = $this->l('Module not installed, install module before updating.');


### PR DESCRIPTION
When uploading a zip of already installed module or without any upgrade changes, an error occurs.