### PR TITLE
Fixed: backoffice header toolbar buttons not visible on some pages

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1628,14 +1628,6 @@ class AdminControllerCore extends Controller
 
         $this->context->smarty->assign('help_link', 'http://help.prestashop.com/'.Language::getIsoById($this->context->employee->id_lang).'/doc/'
             .Tools::getValue('controller').'?version='._PS_VERSION_.'&country='.Language::getIsoById($this->context->employee->id_lang));
-
-        $this->context->smarty->assign(array(
-            'show_page_header_toolbar' => $this->show_page_header_toolbar,
-            'page_header_toolbar_title' => $this->page_header_toolbar_title,
-            'title' => $this->page_header_toolbar_title,
-            'toolbar_btn' => $this->page_header_toolbar_btn,
-            'page_header_toolbar_btn' => $this->page_header_toolbar_btn,
-        ));
     }
 
     /**
@@ -2138,11 +2130,9 @@ class AdminControllerCore extends Controller
         $this->initPageHeaderToolbar();
 
         if ($this->display == 'edit' || $this->display == 'add') {
-            if (!$this->loadObject(true)) {
-                return;
+            if ($this->loadObject(true)) {
+                $this->content .= $this->renderForm();
             }
-
-            $this->content .= $this->renderForm();
         } elseif ($this->display == 'view') {
             // Some controllers use the view action without an object
             if ($this->className) {
@@ -2168,6 +2158,11 @@ class AdminControllerCore extends Controller
             'content' => $this->content,
             'lite_display' => $this->lite_display,
             'url_post' => self::$currentIndex.'&token='.$this->token,
+            'show_page_header_toolbar' => $this->show_page_header_toolbar,
+            'page_header_toolbar_title' => $this->page_header_toolbar_title,
+            'title' => $this->page_header_toolbar_title,
+            'toolbar_btn' => $this->page_header_toolbar_btn,
+            'page_header_toolbar_btn' => $this->page_header_toolbar_btn,
         ));
     }
 

--- a/controllers/admin/AdminEmployeesController.php
+++ b/controllers/admin/AdminEmployeesController.php
@@ -175,6 +175,8 @@ class AdminEmployeesControllerCore extends AdminController
 
     public function initPageHeaderToolbar()
     {
+        parent::initPageHeaderToolbar();
+
         if (empty($this->display)) {
             $this->page_header_toolbar_btn['new_employee'] = array(
                 'href' => self::$currentIndex.'&addemployee&token='.$this->token,
@@ -193,8 +195,6 @@ class AdminEmployeesControllerCore extends AdminController
                     $this->toolbar_title);
             }
         }
-
-        parent::initPageHeaderToolbar();
     }
 
     public function renderList()

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -716,6 +716,8 @@ class AdminThemesControllerCore extends AdminController
 
     public function initPageHeaderToolbar()
     {
+        parent::initPageHeaderToolbar();
+
         if (empty($this->display)) {
             $this->page_header_toolbar_btn['import_theme'] = array(
                 'href' => self::$currentIndex.'&action=importtheme&token='.$this->token,
@@ -744,8 +746,6 @@ class AdminThemesControllerCore extends AdminController
 
         $title = implode(' '.Configuration::get('PS_NAVIGATION_PIPE').' ', $this->toolbar_title);
         $this->page_header_toolbar_title = $title;
-
-        parent::initPageHeaderToolbar();
     }
 
     private function checkParentClass($name)


### PR DESCRIPTION
Back office header toolbar buttons were not visible on admin tax rules, admin theme and admin employees pages.