### PR TITLE
Updated: Disable option to add services when rooms are unavailable

### DIFF
--- a/modules/blockcart/ajax-cart.js
+++ b/modules/blockcart/ajax-cart.js
@@ -1255,6 +1255,16 @@ function disableRoomTypeDemands(show) {
     }
 }
 
+function disableRoomTypeServices(disable) {
+    if (disable) {
+        $('#service_products_cont').find('button.add_roomtype_product').attr('disabled', 'disabled');
+        $('#service_products_cont').find('.qty_container .qty_direction a').attr('disabled', 'disabled');
+    } else {
+        $('#service_products_cont').find('button.add_roomtype_product').removeAttr('disabled');
+        $('#service_products_cont').find('.qty_container .qty_direction a').removeAttr('disabled');
+    }
+}
+
 function getRoomsExtraDemands()
 {
     var roomDemands = [];

--- a/themes/hotel-reservation-theme/js/modules/blockcart/ajax-cart.js
+++ b/themes/hotel-reservation-theme/js/modules/blockcart/ajax-cart.js
@@ -1255,6 +1255,16 @@ function disableRoomTypeDemands(show) {
     }
 }
 
+function disableRoomTypeServices(disable) {
+    if (disable) {
+        $('#service_products_cont').find('button.add_roomtype_product').attr('disabled', 'disabled');
+        $('#service_products_cont').find('.qty_container .qty_direction a').attr('disabled', 'disabled');
+    } else {
+        $('#service_products_cont').find('button.add_roomtype_product').removeAttr('disabled');
+        $('#service_products_cont').find('.qty_container .qty_direction a').removeAttr('disabled');
+    }
+}
+
 function getRoomsExtraDemands()
 {
     var roomDemands = [];

--- a/themes/hotel-reservation-theme/js/product.js
+++ b/themes/hotel-reservation-theme/js/product.js
@@ -1350,8 +1350,10 @@ var BookingForm = {
         }
         if (!$('.max_avail_type_qty').length || $('.max_avail_type_qty').val() < 1) {
             disableRoomTypeDemands(1);
+            disableRoomTypeServices(1);
         } else {
             disableRoomTypeDemands(0);
+            disableRoomTypeServices(0);
         }
     },
     initDatepicker: function(max_order_date, preparation_time, dateFrom, dateTo) {


### PR DESCRIPTION
When rooms are not available for booking, adding services option should be disabled.