### PR TITLE
Fix Average Occupancy Rate issue on dashboard

### DIFF
--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -1107,7 +1107,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
         );
 
         if ($numAllOrders != 0) {
-            return $numCancelledOrders / $numAllOrders * 100;
+            return $numCancelledOrders / $numAllOrders;
         } else {
             return 0;
         }
@@ -1693,7 +1693,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 
         $totalRevenue = (float) self::getRevenue($dateFrom, $dateTo, $idHotel);
 
-        return $totalRevenue ? ($directRevenue / $totalRevenue) * 100 : 0;
+        return $totalRevenue ? ($directRevenue / $totalRevenue) : 0;
     }
 
     public static function getOperatingExpensesForDiscreteDates($dateFrom, $dateTo = null, $idHotel = null, $useCache = true)

--- a/modules/dashperformance/dashperformance.php
+++ b/modules/dashperformance/dashperformance.php
@@ -88,7 +88,7 @@ class DashPerformance extends Module
                 $params['date_from'],
                 $params['date_to'],
                 $params['id_hotel']
-            )).'%';
+            ) * 100).'%';
             $data['dp_revenue_per_available_room'] = Tools::displayPrice(AdminStatsController::getRevenuePerAvailableRoom(
                 $params['date_from'],
                 $params['date_to'],
@@ -108,12 +108,12 @@ class DashPerformance extends Module
                 $params['date_from'],
                 $params['date_to'],
                 $params['id_hotel']
-            )).'%';
+            ) * 100).'%';
             $data['dp_cancellation_rate'] = sprintf('%0.2f', AdminStatsController::getCancellationRate(
                 $params['date_from'],
                 $params['date_to'],
                 $params['id_hotel']
-            )).'%';
+            ) * 100).'%';
         }
 
         return array('data_value' => $data);


### PR DESCRIPTION
The Average Occupancy Rate value has now been fixed to be calculated as a percentage.