### PR TITLE
Fix 'Best hotels' and 'Best-selling room types' issues on Stats > Stats page

### DIFF
--- a/modules/statsbestcategories/statsbestcategories.php
+++ b/modules/statsbestcategories/statsbestcategories.php
@@ -152,6 +152,9 @@ class StatsBestCategories extends ModuleGrid
         $date_between = $this->getDate();
         $date_from = date('Y-m-d', strtotime($this->_employee->stats_date_from));
         $date_to = date('Y-m-d', strtotime($this->_employee->stats_date_to));
+        if ($date_from == $date_to) {
+            $date_to = date('Y-m-d', strtotime('+1 day', strtotime($date_to)));
+        }
         $id_lang = $this->getLang();
 
         //If column 'order_detail.original_wholesale_price' does not exist, create it

--- a/modules/statsbestproducts/statsbestproducts.php
+++ b/modules/statsbestproducts/statsbestproducts.php
@@ -154,6 +154,9 @@ class StatsBestProducts extends ModuleGrid
         $date_between = $this->getDate();
         $date_from = date('Y-m-d', strtotime($this->_employee->stats_date_from));
         $date_to = date('Y-m-d', strtotime($this->_employee->stats_date_to));
+        if ($date_from == $date_to) {
+            $date_to = date('Y-m-d', strtotime('+1 day', strtotime($date_to)));
+        }
         $array_date_between = explode(' AND ', $date_between);
         $id_lang = $this->getLang();
 


### PR DESCRIPTION
The data calculated in case of Day selection from calendar was showing incorrect data.