### PR TITLE
Fix image display issue on homepage

### DIFF
--- a/modules/wkabouthotelblock/views/css/WkAboutHotelBlockFront.css
+++ b/modules/wkabouthotelblock/views/css/WkAboutHotelBlockFront.css
@@ -40,6 +40,8 @@
 }
 .interiorboxInner img {
    width: 100%;
+   height: 100%;
+   object-fit: cover;
 }
 .htlInterior-owlCarousel .owl-prev, .htlInterior-owlCarousel .owl-next{
     font-size: 40px;


### PR DESCRIPTION
The Interior block images on homepage will now be displayed correctly covering maximum image.