### PR TITLE
Removed:  "go to payment page" option from admin order create page when creating order for backdate 

### DIFF
--- a/admin/themes/default/template/controllers/orders/form.tpl
+++ b/admin/themes/default/template/controllers/orders/form.tpl
@@ -1179,7 +1179,12 @@
 		$('#id_lang option').removeAttr('selected');
 		$('#id_lang option[value="'+id_lang+'"]').attr('selected', true);
 		$('#send_email_to_customer').attr('rel', jsonSummary.link_order);
-		$('#go_order_process').attr('href', jsonSummary.link_order);
+		if (!jsonSummary.is_backdate_order) {
+			$('#go_order_process').show();
+			$('#go_order_process').attr('href', jsonSummary.link_order);
+		} else {
+			$('#go_order_process').hide();
+		}
 		$('#order_message').val(jsonSummary.order_message);
 		resetBind();
 	}

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -844,6 +844,14 @@ class AdminCartsControllerCore extends AdminController
             }
         }
 
+        $cart_detail_data_obj = new HotelCartBookingData();
+        $cart_detail_data = $cart_detail_data_obj->getCartFormatedBookinInfoByIdCart((int) $id_cart);
+        $is_backdate_order = false;
+        foreach ($cart_detail_data as $cartRoom) {
+            if (strtotime($cartRoom['date_from']) < strtotime(date('Y-m-d'))) {
+                $is_backdate_order = true;
+            }
+        }
         $addresses = $this->context->customer->getAddresses((int)$this->context->cart->id_lang);
 
         foreach ($addresses as &$data) {
@@ -853,6 +861,8 @@ class AdminCartsControllerCore extends AdminController
 
         return array(
             'summary' => $this->getCartSummary(),
+            'cart_detail_data' => $cart_detail_data,
+            'is_backdate_order' => $is_backdate_order,
             'delivery_option_list' => $this->getDeliveryOptionList(),
             'cart' => $this->context->cart,
             'currency' => new Currency($this->context->cart->id_currency),

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -847,8 +847,9 @@ class AdminCartsControllerCore extends AdminController
         $cart_detail_data_obj = new HotelCartBookingData();
         $cart_detail_data = $cart_detail_data_obj->getCartFormatedBookinInfoByIdCart((int) $id_cart);
         $is_backdate_order = false;
+        $currentDate = strtotime(date('Y-m-d'));
         foreach ($cart_detail_data as $cartRoom) {
-            if (strtotime($cartRoom['date_from']) < strtotime(date('Y-m-d'))) {
+            if (strtotime($cartRoom['date_from']) < $currentDate) {
                 $is_backdate_order = true;
             }
         }


### PR DESCRIPTION
When creating an order for backdate, removed the option "Go on payment page to process the payment" to prevent cart rooms from deleting