### PR TITLE
Fixed: Datepicker not initializing on initial load of room type page with preperation time

### DIFF
--- a/themes/hotel-reservation-theme/js/product.js
+++ b/themes/hotel-reservation-theme/js/product.js
@@ -1359,11 +1359,13 @@ var BookingForm = {
         if (preparation_time) {
             start_date.setDate(start_date.getDate() + parseInt(preparation_time));
             start_date.setHours(0, 0, 0, 0);
-            if (dateFrom && new Date(dateFrom) < start_date) {
+            if (dateFrom && new Date(dateFrom + ' 00:00:00') < start_date) {
                 dateFrom = $.datepicker.formatDate('yy-mm-dd', start_date);
-                dateTo = new Date(start_date);
-                dateTo.setDate(start_date.getDate() + 1);
-                dateTo = $.datepicker.formatDate('yy-mm-dd', dateTo);
+                if (new Date(dateTo + ' 00:00:00') <= start_date) {
+                    dateTo = new Date(start_date);
+                    dateTo.setDate(start_date.getDate() + 1);
+                    dateTo = $.datepicker.formatDate('yy-mm-dd', dateTo);
+                }
             }
         }
 

--- a/themes/hotel-reservation-theme/js/product.js
+++ b/themes/hotel-reservation-theme/js/product.js
@@ -1359,6 +1359,12 @@ var BookingForm = {
         if (preparation_time) {
             start_date.setDate(start_date.getDate() + parseInt(preparation_time));
             start_date.setHours(0, 0, 0, 0);
+            if (dateFrom && new Date(dateFrom) < start_date) {
+                dateFrom = $.datepicker.formatDate('yy-mm-dd', start_date);
+                dateTo = new Date(start_date);
+                dateTo.setDate(start_date.getDate() + 1);
+                dateTo = $.datepicker.formatDate('yy-mm-dd', dateTo);
+            }
         }
 
         if (max_order_date) {
@@ -1382,7 +1388,6 @@ var BookingForm = {
             max_order_date = $.datepicker.formatDate('dd-mm-yy', max_order_date);
         }
         $('#room_date_range').dateRangePicker({
-            startDate: $.datepicker.formatDate('dd-mm-yy', new Date()),
             endDate: max_order_date,
             startDate: start_date,
         }).on('datepicker-change', function(event,obj){


### PR DESCRIPTION
Datepicker does not get initialized on initial load of room type page when preperation time is more than selected check-in date