### PR TITLE
Add default contact phone and email at front office nav bar

### DIFF
--- a/modules/qloblockcontact/qloblockcontact.php
+++ b/modules/qloblockcontact/qloblockcontact.php
@@ -41,8 +41,8 @@ class QloBlockContact extends Module
     public function install()
     {
         if (!parent::install()
-            || !Configuration::updateValue('QBC_PHONE', '')
-            || !Configuration::updateValue('QBC_EMAIL', '')
+            || !Configuration::updateValue('QBC_PHONE', Configuration::get('WK_HOTEL_GLOBAL_CONTACT_NUMBER'))
+            || !Configuration::updateValue('QBC_EMAIL', Configuration::get('WK_HOTEL_GLOBAL_CONTACT_EMAIL'))
             || !$this->registerHook('actionFrontControllerSetMedia')
             || !$this->registerHook('displayNav')
             || !$this->registerHook('displayExternalNavigationHook')


### PR DESCRIPTION
Default global contact info has been added to nav bar. It can be changed from QloApps Contact Block module's configuration page.