### PR TITLE
Fixed: dashboard  graphs errors when data set is empty

### DIFF
--- a/modules/dashinsights/views/js/dashinsights.js
+++ b/modules/dashinsights/views/js/dashinsights.js
@@ -18,6 +18,7 @@
  */
 
 function line_chart_dashinsights(widget_name, chart_details) {
+    $('#dashinsights_room_nights svg').html('');
     nv.addGraph(function () {
         var chart = nv.models.lineChart()
             .useInteractiveGuideline(true)
@@ -46,6 +47,7 @@ function line_chart_dashinsights(widget_name, chart_details) {
 }
 
 function multibar_chart_dotw_dashinsights(widget_name, chart_details) {
+    $('#dashinsights_days_of_the_week svg').html('');
     nv.addGraph(function() {
         var chart = nv.models.multiBarHorizontalChart()
             .showControls(false)
@@ -71,6 +73,7 @@ function multibar_chart_dotw_dashinsights(widget_name, chart_details) {
 }
 
 function multibar_chart_los_dashinsights(widget_name, chart_details) {
+    $('#dashinsights_length_of_stay svg').html('')
     nv.addGraph(function() {
         var chart = nv.models.multiBarHorizontalChart()
             .showControls(false)

--- a/modules/dashoccupancy/dashoccupancy.php
+++ b/modules/dashoccupancy/dashoccupancy.php
@@ -88,26 +88,30 @@ class DashOccupancy extends Module
             'do_count_unavailable' => sprintf('%02d', $occupancyData['count_unavailable']),
         );
 
-        $dataPieChartBig = array(
-            array(
-                'label' => $this->l('Occupied'),
-                'value' => $occupancyData['count_total']
-                    ? ($occupancyData['count_occupied'] / $occupancyData['count_total']) * 100
-                    : 0,
-            ),
-            array(
-                'label' => $this->l('Available'),
-                'value' => $occupancyData['count_total']
-                    ? ($occupancyData['count_available'] / $occupancyData['count_total']) * 100
-                    : 0,
-            ),
-            array(
-                'label' => $this->l('Unavailable'),
-                'value' => $occupancyData['count_total']
-                    ? ($occupancyData['count_unavailable'] / $occupancyData['count_total']) * 100
-                    : 0,
-            ),
-        );
+        if ($occupancyData['count_total']) {
+            $dataPieChartBig = array(
+                array(
+                    'label' => $this->l('Occupied'),
+                    'value' => $occupancyData['count_total']
+                        ? ($occupancyData['count_occupied'] / $occupancyData['count_total']) * 100
+                        : 0,
+                ),
+                array(
+                    'label' => $this->l('Available'),
+                    'value' => $occupancyData['count_total']
+                        ? ($occupancyData['count_available'] / $occupancyData['count_total']) * 100
+                        : 0,
+                ),
+                array(
+                    'label' => $this->l('Unavailable'),
+                    'value' => $occupancyData['count_total']
+                        ? ($occupancyData['count_unavailable'] / $occupancyData['count_total']) * 100
+                        : 0,
+                ),
+            );
+        } else {
+            $dataPieChartBig = array();
+        }
 
         return array(
             'data_value' => $dataValue,

--- a/modules/dashoccupancy/views/js/dashoccupancy.js
+++ b/modules/dashoccupancy/views/js/dashoccupancy.js
@@ -18,7 +18,8 @@
  */
 
 function pie_chart_occupancy(widget_name, chart_details) {
-    nv.addGraph(function() {
+    $('#availablePieChart svg').html('');
+    occupacygraph = nv.addGraph(function() {
         var chart = nv.models.pieChart()
             .x(function(d) { return d.label })
             .y(function(d) { return d.value })

--- a/modules/hotelreservationsystem/classes/HotelBranchInformation.php
+++ b/modules/hotelreservationsystem/classes/HotelBranchInformation.php
@@ -780,13 +780,17 @@ class HotelBranchInformation extends ObjectModel
         } else {
             $idsHotel = array($idsHotel);
         }
+        $restriction = ' AND ';
+        if (count($idsHotel)) {
+            if ($alias) {
+                $alias .= '.';
+            }
 
-        if ($alias) {
-            $alias .= '.';
+            $identifier = "`$identifier`";
+            $restriction .= $alias.$identifier.' IN ('.implode(', ', $idsHotel).') ';
+        } else {
+            $restriction .= 1;
         }
-
-        $identifier = "`$identifier`";
-        $restriction = ' AND '.$alias.$identifier.' IN ('.implode(', ', $idsHotel).') ';
 
         return $restriction;
     }


### PR DESCRIPTION
When there are no hotels and room types in QloApps, occupancy and insight graphs does not get created on the dashboard