### PR TITLE
Removed: In the manage category page removed description column from list

### DIFF
--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -72,11 +72,11 @@ class AdminCategoriesControllerCore extends AdminController
             'name' => array(
                 'title' => $this->l('Name')
             ),
-            'description' => array(
-                'title' => $this->l('Description'),
-                'callback' => 'getDescriptionClean',
-                'orderby' => false
-            ),
+            // 'description' => array(
+            //     'title' => $this->l('Description'),
+            //     'callback' => 'getDescriptionClean',
+            //     'orderby' => false
+            // ),
             'position' => array(
                 'title' => $this->l('Position'),
                 'filter_key' => 'sa!position',


### PR DESCRIPTION
In the manage category page description column was visible but the category form does not have the option to add description.