### PR TITLE
Remove specific price warning in manage services page

### DIFF
--- a/controllers/admin/AdminNormalProductsController.php
+++ b/controllers/admin/AdminNormalProductsController.php
@@ -2947,7 +2947,6 @@ class AdminNormalProductsControllerCore extends AdminController
             // get hotel address for this room type
             $address_infos = Address::getCountryAndState(Cart::getIdAddressForTaxCalculation($obj->id));
         } else {
-            $this->displayWarning($this->l('You must save this product before adding specific pricing'));
             $product->id_tax_rules_group = (int)Product::getIdTaxRulesGroupMostUsed();
             $data->assign('ecotax_tax_excl', 0);
         }


### PR DESCRIPTION
In manage services page, specific price option does not exists so removing the warining