### PR TITLE
Resolved: Fatal error when set Awaiting Payment order status as logable and creating partial payment

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1006,7 +1006,7 @@ abstract class PaymentModuleCore extends Module
                     $new_history = new OrderHistory();
                     $new_history->id_order = (int)$order->id;
                     if ($order_status->logable && $order->is_advance_payment && $order->advance_paid_amount < $order->total_paid_tax_incl) {
-                        $new_history->changeIdOrderState((int)Configuration::get('PS_OS_PARTIAL_PAYMENT'), $order, true);
+                        $new_history->changeIdOrderState((int)Configuration::get('PS_OS_PARTIAL_PAYMENT_ACCEPTED'), $order, true);
                     } else {
                         $new_history->changeIdOrderState((int)$id_order_state, $order, true);
                     }


### PR DESCRIPTION
**Issue:** 
Fatal error occurs when setting **Consider the associated order as validated** as checked in **Awaiting Payment** order status and creating partial payment with Bankwire or other payment gateways