### PR TITLE
Fixed: Hotel permissions are not saved when a hotel is created

### DIFF
--- a/modules/hotelreservationsystem/classes/HotelBranchInformation.php
+++ b/modules/hotelreservationsystem/classes/HotelBranchInformation.php
@@ -136,9 +136,9 @@ class HotelBranchInformation extends ObjectModel
 
         /* Query definition */
         $query = 'REPLACE INTO `'._DB_PREFIX_.'htl_access` (`id_profile`, `id_hotel`, `access`)';
-        $query .= ' VALUES '.'(1, '.(int)$idHotel.', 1)';
+        $query .= ' VALUES '.'('.(int) _PS_ADMIN_PROFILE_.', '.(int)$idHotel.', 1)';
         /* Profile selection */
-        $profiles = Db::getInstance()->executeS('SELECT `id_profile` FROM '._DB_PREFIX_.'profile WHERE `id_profile` != 1');
+        $profiles = Db::getInstance()->executeS('SELECT `id_profile` FROM '._DB_PREFIX_.'profile WHERE `id_profile` != '.(int) _PS_ADMIN_PROFILE_);
         if ($profiles) {
             foreach ($profiles as $profile) {
                 $access = 0;

--- a/modules/hotelreservationsystem/classes/HotelBranchInformation.php
+++ b/modules/hotelreservationsystem/classes/HotelBranchInformation.php
@@ -139,7 +139,7 @@ class HotelBranchInformation extends ObjectModel
         $query .= ' VALUES '.'(1, '.(int)$idHotel.', 1)';
         /* Profile selection */
         $profiles = Db::getInstance()->executeS('SELECT `id_profile` FROM '._DB_PREFIX_.'profile WHERE `id_profile` != 1');
-        if (!$profiles || empty($profiles)) {
+        if ($profiles) {
             foreach ($profiles as $profile) {
                 $access = 0;
                 if (isset($context->employee->id_profile)) {


### PR DESCRIPTION
The employee creating the hotel is unable to make changes to the hotel created by him.

The permission was not saving properly on database when a hotel is created.