### PR TITLE
Fixed: PHP warning on Booking Carts > View page at back office if address of the cart customer is deleted

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -1300,7 +1300,8 @@ class CarrierCore extends ObjectModel
         }
 
         $id_address = (int)((!is_null($id_address_delivery) && $id_address_delivery != 0) ? $id_address_delivery :  $cart->id_address_delivery);
-        if ($id_address) {
+        $obj_address = new Address($id_address);
+        if (Validate::isLoadedObject($obj_address)) {
             $id_zone = Address::getZoneById($id_address);
 
             // Check the country of the address is activated


### PR DESCRIPTION
The PHP warning appears if the address of the cart customer is deleted.