### PR TITLE
Fixed: Fatal error: Uncaught Error: Class 'HTMLPurifier_Config' not found when enabling HTMLPurifier library

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3603,6 +3603,8 @@ exit;
 
     public static function purifyHTML($html, $uri_unescape = null, $allow_style = false)
     {
+        require_once(_PS_TOOL_DIR_.'htmlpurifier/HTMLPurifier.auto.php');
+
         static $use_html_purifier = null;
         static $purifier = null;
 


### PR DESCRIPTION
Issue steps:
1. Disbale 'Use HTMLPurifier Library' from Preferences > General page.
2. Enable the option above and click Save.