### PR TITLE
Fixed: Admin can not set refund amount to 0 when creating refund rules

### DIFF
--- a/modules/hotelreservationsystem/controllers/admin/AdminOrderRefundRulesController.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminOrderRefundRulesController.php
@@ -213,10 +213,10 @@ class AdminOrderRefundRulesController extends ModuleAdminController
         if ($paymentType == '') {
             $this->errors[] = $this->l('Invalid payment type.');
         }
-        if (!$fullPayAmount) {
+        if (!$fullPayAmount && floatval($fullPayAmount) != 0) {
             $this->errors[] = $this->l('Enter deduction value for full payment.');
         }
-        if (!$advPayAmount) {
+        if (!$advPayAmount && floatval($advPayAmount) != 0) {
             $this->errors[] = $this->l('Enter deduction value for advance payment.');
         }
 


### PR DESCRIPTION
This PR will allow deduction values to be set as 0 when saving refund rules.