### PR TITLE
Open room type detail page in same tab from Our Rooms block on landing page

### DIFF
--- a/modules/wkhotelroom/views/templates/hook/hotelRoomDisplayBlock.tpl
+++ b/modules/wkhotelroom/views/templates/hook/hotelRoomDisplayBlock.tpl
@@ -58,7 +58,7 @@
                                             {$roomDisplay.description}
                                         </div>
                                         <div class="row margin-lr-0">
-                                            <a target="_blank" class="btn btn-default button htlRoomTypeBookNow" href="{$link->getProductLink($roomDisplay.id_product)|escape:'html':'UTF-8'}"><span>{if !isset($restricted_country_mode) && !$PS_CATALOG_MODE}{l s='book now' mod='wkhotelroom'}{else}{l s='View' mod='wkhotelroom'}{/if}</span></a>
+                                            <a class="btn btn-default button htlRoomTypeBookNow" href="{$link->getProductLink($roomDisplay.id_product)|escape:'html':'UTF-8'}"><span>{if !isset($restricted_country_mode) && !$PS_CATALOG_MODE}{l s='book now' mod='wkhotelroom'}{else}{l s='View' mod='wkhotelroom'}{/if}</span></a>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
The room type detail page will now open in the same page when clicking Book Now button.