### PR TITLE
Display voucher table only if needed on Order view at back office

### DIFF
--- a/admin/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -1228,7 +1228,7 @@
 						</div>
 						<div class="col-xs-6 pull-right">
 							<div class="panel panel-vouchers" style="{if !sizeof($discounts)}display:none;{/if}">
-								{if (sizeof($discounts) || $can_edit)}
+								{if sizeof($discounts)}
 									<div class="table-responsive">
 										<table class="table">
 											<thead>
@@ -1271,6 +1271,8 @@
 											</tbody>
 										</table>
 									</div>
+								{/if}
+								{if $can_edit}
 									<div class="current-edit" id="voucher_form" style="display:none;">
 										{include file='controllers/orders/_discount_form.tpl'}
 									</div>


### PR DESCRIPTION
The discounts table will not be displayed if there are no discounts applied to the order.