### PR TITLE
Fixed: Time picker not available in payment block on order detail page at back office

### DIFF
--- a/admin/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -2098,7 +2098,8 @@
 		$('.datepicker').datetimepicker({
 			prevText: '',
 			nextText: '',
-			dateFormat: 'yy-mm-dd ' + hours + ':' + mins + ':' + secs
+			dateFormat: 'yy-mm-dd',
+			timeFormat: 'hh:mm:ss',
 		});
 	});
 </script>


### PR DESCRIPTION
The time picker will also be displayed with the datepicker when adding payment on order detail page.