### PR TITLE
Fixed: Unable to delete room types from cart if admin visits book now page just after booking creation and before order confirmation

### DIFF
--- a/modules/hotelreservationsystem/controllers/admin/AdminHotelRoomsBookingController.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminHotelRoomsBookingController.php
@@ -45,9 +45,8 @@ class AdminHotelRoomsBookingController extends ModuleAdminController
         } else {
             // use previous cart
             $objCart = new Cart($this->context->cookie->id_cart);
-            if (!Validate::isLoadedObject($objCart)
-                || (Validate::isLoadedObject($objCart) && $objCart->orderExists())
-            ) {
+            $isCartValid = Validate::isLoadedObject($objCart);
+            if (!$isCartValid || ($isCartValid && $objCart->orderExists())) {
                 $objCart = $this->createNewCart();
                 $this->context->cookie->id_cart = (int) $objCart->id;
             }

--- a/modules/hotelreservationsystem/controllers/admin/AdminHotelRoomsBookingController.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminHotelRoomsBookingController.php
@@ -44,8 +44,12 @@ class AdminHotelRoomsBookingController extends ModuleAdminController
             $this->context->cookie->id_cart = (int) $objCart->id;
         } else {
             // use previous cart
-            if (!validate::isLoadedObject($objCart = new Cart($this->context->cookie->id_cart))) {
+            $objCart = new Cart($this->context->cookie->id_cart);
+            if (!Validate::isLoadedObject($objCart)
+                || (Validate::isLoadedObject($objCart) && $objCart->orderExists())
+            ) {
                 $objCart = $this->createNewCart();
+                $this->context->cookie->id_cart = (int) $objCart->id;
             }
         }
         $this->context->cart = $objCart;


### PR DESCRIPTION
The issue was caused because it is not checked if cart in context already has an order. Now, the cart is removed from the context if an order has already been placed in the current 'id_cart'.