### PR TITLE
Set default customer group to Customer when transforming Guest account

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -796,6 +796,7 @@ class CustomerCore extends ObjectModel
         $this->passwd = Tools::encrypt($password);
         $this->cleanGroups();
         $this->addGroups(array(Configuration::get('PS_CUSTOMER_GROUP'))); // add default customer group
+        $this->id_default_group = (int) Configuration::get('PS_CUSTOMER_GROUP');
         if ($this->update()) {
             $vars = array(
                 '{firstname}' => $this->firstname,


### PR DESCRIPTION
Earlier the default customer group was left to Guest as it is preventing customer from availing discounts for Customer group. The default customer group has now been changed to Customer.