### PR TITLE
Fixed: Link::getMediaLink() not used for invoice logo

### DIFF
--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -100,10 +100,10 @@ abstract class HTMLTemplateCore
 
         $id_shop = (int)$this->shop->id;
 
-        if (Configuration::get('PS_LOGO_INVOICE', null, null, $id_shop) != false && file_exists(_PS_IMG_DIR_.Configuration::get('PS_LOGO_INVOICE', null, null, $id_shop))) {
-            $logo = _PS_IMG_DIR_.Configuration::get('PS_LOGO_INVOICE', null, null, $id_shop);
-        } elseif (Configuration::get('PS_LOGO', null, null, $id_shop) != false && file_exists(_PS_IMG_DIR_.Configuration::get('PS_LOGO', null, null, $id_shop))) {
-            $logo = _PS_IMG_DIR_.Configuration::get('PS_LOGO', null, null, $id_shop);
+        if (Configuration::get('PS_LOGO_INVOICE', null, null, $id_shop) != false) {
+            $logo = Context::getContext()->link->getMediaLink(_PS_IMG_.Configuration::get('PS_LOGO_INVOICE', null, null, $id_shop));
+        } elseif (Configuration::get('PS_LOGO', null, null, $id_shop) != false) {
+            $logo = Context::getContext()->link->getMediaLink(_PS_IMG_.Configuration::get('PS_LOGO', null, null, $id_shop));
         }
         return $logo;
     }


### PR DESCRIPTION
This change has been made to allow Media Servers to server invoice logo.