### PR TITLE
Fixed: Admin is able to apply voucher created for a customer to another customer

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -249,10 +249,9 @@ abstract class PaymentModuleCore extends Module
             // Make sure CartRule caches are empty
             CartRule::cleanCache();
             $cart_rules = $this->context->cart->getCartRules();
-            foreach ($cart_rules as $key => $cart_rule) {
+            foreach ($cart_rules as $cart_rule) {
                 if (($rule = new CartRule((int)$cart_rule['obj']->id)) && Validate::isLoadedObject($rule)) {
                     if ($error = $rule->checkValidity($this->context, true, true)) {
-                        unset($cart_rules[$key]);
                         $this->context->cart->removeCartRule((int)$rule->id);
                         if (isset($this->context->cookie) && isset($this->context->cookie->id_customer) && $this->context->cookie->id_customer && !empty($rule->code)) {
                             if (Configuration::get('PS_ORDER_PROCESS_TYPE') == 1) {

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -249,9 +249,10 @@ abstract class PaymentModuleCore extends Module
             // Make sure CartRule caches are empty
             CartRule::cleanCache();
             $cart_rules = $this->context->cart->getCartRules();
-            foreach ($cart_rules as $cart_rule) {
+            foreach ($cart_rules as $key => $cart_rule) {
                 if (($rule = new CartRule((int)$cart_rule['obj']->id)) && Validate::isLoadedObject($rule)) {
                     if ($error = $rule->checkValidity($this->context, true, true)) {
+                        unset($cart_rules[$key]);
                         $this->context->cart->removeCartRule((int)$rule->id);
                         if (isset($this->context->cookie) && isset($this->context->cookie->id_customer) && $this->context->cookie->id_customer && !empty($rule->code)) {
                             if (Configuration::get('PS_ORDER_PROCESS_TYPE') == 1) {

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -333,6 +333,9 @@ class AdminCartsControllerCore extends AdminController
             }
             $this->context->cart = new Cart((int)$id_cart);
 
+            CartRule::autoRemoveFromCart($this->context);
+            CartRule::autoAddToCart($this->context);
+
             if (!$this->context->cart->id) {
                 $this->context->cart->recyclable = 0;
                 $this->context->cart->gift = 0;


### PR DESCRIPTION
When creating an order from back office admin was able to use the cart rule restricted to a specific customer for another customer  by changing the customer as the last step during order creation.