### PR TITLE
Fixed: Groups selection is removed for Advanced Price Rule when status is changed

### DIFF
--- a/modules/hotelreservationsystem/classes/HotelRoomTypeFeaturePricing.php
+++ b/modules/hotelreservationsystem/classes/HotelRoomTypeFeaturePricing.php
@@ -823,8 +823,8 @@ class HotelRoomTypeFeaturePricing extends ObjectModel
      */
     public function updateGroup($groups)
     {
-        $this->cleanGroups();
         if ($groups && !empty($groups)) {
+            $this->cleanGroups();
             $this->addGroups($groups);
         }
     }


### PR DESCRIPTION
Groups will remain as it is if changing status of an Advanced Price Rule.