### PR TITLE
Fixed: File '/cache/smarty/compile/index.php' gets deleted when clearing cache causing warning on Configuration Information page

### DIFF
--- a/tools/smarty/sysplugins/smarty_internal_method_clearcompiledtemplate.php
+++ b/tools/smarty/sysplugins/smarty_internal_method_clearcompiledtemplate.php
@@ -114,6 +114,11 @@ class Smarty_Internal_Method_ClearCompiledTemplate
                         $unlink = true;
                     }
                 }
+
+                if (substr($_filepath, -9) == 'index.php') {
+                    $unlink = false;
+                }
+
                 if ($unlink && is_file($_filepath) && @unlink($_filepath)) {
                     $_count++;
                     if (function_exists('opcache_invalidate')


### PR DESCRIPTION
1. If file '/cache/smarty/compile/index.php' is deleted we get warning on Advanced Parameters > Configuration Information page.
2. Also this file is required during installation.