### PR TITLE
Fixed: 'Add a new module' button is displayed even if current employee is not allowed to install modules

### DIFF
--- a/admin/themes/default/template/controllers/modules/content.tpl
+++ b/admin/themes/default/template/controllers/modules/content.tpl
@@ -36,7 +36,7 @@
 				<div class="panel">
 					<div class="row">
 						<div class="col-lg-3 col-md-4 col-sm-12 col-xs-12">
-							<img class="img-responsive" alt="PrestaShop Addons" src="themes/default/img/prestashop-addons-logo.png">
+							<img class="img-responsive" alt="QloApps Addons" src="themes/default/img/prestashop-addons-logo.png">
 						</div>
 						<div class="col-lg-4 col-lg-offset-1 col-md-4 col-sm-7 col-xs-12 addons-style-search-bar">
 							<form id="addons-search-form" method="get" action="http://addons.prestashop.com/{$iso_code}/search" class="float">
@@ -64,7 +64,7 @@
 
 					<div class="form-wrapper">
 						<div class="form-group">
-							<p>{l s='To add a new module, simply connect to your PrestaShop Addons account and all your purchases will be automatically imported.'}</p>
+							<p>{l s='To add a new module, simply connect to your QloApps Addons account and all your purchases will be automatically imported.'}</p>
 						</div>
 					</div><!-- /.form-wrapper -->
 
@@ -82,7 +82,7 @@
 
 				<div class="alert alert-info">
 					<h4>{l s='Can I add my own modules?'}</h4>
-					<p>{l s='Please note that for security reasons, you can only add modules that are being distributed on PrestaShop Addons, the official marketplace.'}</p>
+					<p>{l s='Please note that for security reasons, you can only add modules that are being distributed on QloApps Addons, the official marketplace.'}</p>
 				</div>
 
 		</div>

--- a/admin/themes/default/template/controllers/modules/page_header_toolbar.tpl
+++ b/admin/themes/default/template/controllers/modules/page_header_toolbar.tpl
@@ -67,20 +67,22 @@
 					<div>{l s='Recommended Modules and Services'}</div>
 				</a>
 			</li>
-			{if $add_permission eq '1' && ($context_mode != Context::MODE_HOST)}
-			<li>
-				<a id="desc-module-new" class="toolbar_btn anchor" href="#" onclick="$('#module_install').slideToggle();" title="{l s='Add a new module'}">
-					<i class="process-icon-new"></i>
-					<div>{l s='Add a new module'}</div>
-				</a>
-			</li>
-			{else}
-			<li>
-				<a id="desc-module-new" class="toolbar_btn" href="{$link->getAdminLink('AdminModules')}&addnewmodule" title="{l s='Add a new module'}">
-					<i class="process-icon-new"></i>
-					<div>{l s='Add a new module'}</div>
-				</a>
-			</li>
+			{if $add_permission eq '1'}
+				{if $context_mode != Context::MODE_HOST}
+					<li>
+						<a id="desc-module-new" class="toolbar_btn anchor" href="#" onclick="$('#module_install').slideToggle();" title="{l s='Add a new module'}">
+							<i class="process-icon-new"></i>
+							<div>{l s='Add a new module'}</div>
+						</a>
+					</li>
+				{else}
+					<li>
+						<a id="desc-module-new" class="toolbar_btn" href="{$link->getAdminLink('AdminModules')}&addnewmodule" title="{l s='Add a new module'}">
+							<i class="process-icon-new"></i>
+							<div>{l s='Add a new module'}</div>
+						</a>
+					</li>
+				{/if}
 			{/if}
 			{if isset($help_link)}
 			{* <li>


### PR DESCRIPTION
If employee does not have permission to add a new module this button will not be displayed.