### PR TITLE
Fixed: Cancellation charge amount is incorrect if order currency is other than default currency

### DIFF
--- a/modules/hotelreservationsystem/classes/HotelOrderRefundRules.php
+++ b/modules/hotelreservationsystem/classes/HotelOrderRefundRules.php
@@ -186,14 +186,6 @@ class HotelOrderRefundRules extends ObjectModel
                                 if ($refRule['payment_type'] == HotelOrderRefundRules::WK_REFUND_RULE_PAYMENT_TYPE_PERCENTAGE) {
                                     $bookingCancellationDetail['reduction_type'] = HotelOrderRefundRules::WK_REFUND_RULE_PAYMENT_TYPE_PERCENTAGE;
                                     $bookingCancellationDetail['cancelation_charge'] = $paidAmount * ($refundValue / 100);
-
-                                    if ($defaultCurrency != $orderCurrency) {
-                                        $bookingCancellationDetail['cancelation_charge'] = Tools::convertPriceFull(
-                                            $bookingCancellationDetail['cancelation_charge'],
-                                            $objDefaultCurrency,
-                                            $objOrderCurrency
-                                        );
-                                    }
                                 } else {
                                     $bookingCancellationDetail['reduction_type'] = HotelOrderRefundRules::WK_REFUND_RULE_PAYMENT_TYPE_FIXED;
                                     if ($defaultCurrency != $orderCurrency) {


### PR DESCRIPTION
The cancellation charge amount will now be calculated only if required.