### PR TITLE
Fixed: SMARTY_DEBUG in URL to enable smarty debug not working

### DIFF
--- a/classes/Smarty/SmartyDev.php
+++ b/classes/Smarty/SmartyDev.php
@@ -29,6 +29,7 @@ class SmartyDev extends Smarty
     public function __construct()
     {
         parent::__construct();
+        $this->debugging_ctrl = 'URL';
         $this->template_class = 'Smarty_Dev_Template';
     }
 


### PR DESCRIPTION
If SMARTY_DEBUG is put in URL now, smarty debug popup willl be opened if debug mode is enabled.