### PR TITLE
Fixed: PHP warning for key 'id_country' on search results page

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2588,7 +2588,7 @@ class ProductCore extends ObjectModel
             $id_country = (int) Configuration::get('PS_COUNTRY_DEFAULT');
         }
 
-	return SpecificPrice::getProductIdByDate(
+	    return SpecificPrice::getProductIdByDate(
             $context->shop->id,
             $context->currency->id,
             $id_country,

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2579,14 +2579,16 @@ class ProductCore extends ObjectModel
         }
 
         $id_address = $context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')};
-
-        $id_country = (int) Configuration::get('PS_COUNTRY_DEFAULT');
         $ids = Address::getCountryAndState($id_address);
+
+        $id_country = null;
         if (isset($ids['id_country']) && (int) $ids['id_country']) {
             $id_country = (int) $ids['id_country'];
+        } else {
+            $id_country = (int) Configuration::get('PS_COUNTRY_DEFAULT');
         }
 
-        return SpecificPrice::getProductIdByDate(
+	return SpecificPrice::getProductIdByDate(
             $context->shop->id,
             $context->currency->id,
             $id_country,

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2579,8 +2579,12 @@ class ProductCore extends ObjectModel
         }
 
         $id_address = $context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')};
+
+        $id_country = (int) Configuration::get('PS_COUNTRY_DEFAULT');
         $ids = Address::getCountryAndState($id_address);
-	$id_country = $ids['id_country'] ? (int) $ids['id_country'] : (int) Configuration::get('PS_COUNTRY_DEFAULT');
+        if (isset($ids['id_country']) && (int) $ids['id_country']) {
+            $id_country = (int) $ids['id_country'];
+        }
 
         return SpecificPrice::getProductIdByDate(
             $context->shop->id,


### PR DESCRIPTION
The key 'id_country' will now be checked before trying to access it.