### PR TITLE
Fixed: HelperForm input type 'group' submit name can not be changed

### DIFF
--- a/admin/themes/default/template/helpers/form/form_group.tpl
+++ b/admin/themes/default/template/helpers/form/form_group.tpl
@@ -31,13 +31,13 @@
 				<tr>
 					<th class="fixed-width-xs">
 						<span class="title_box">
-							<input type="checkbox" name="checkme" id="checkme" onclick="checkDelBoxes(this.form, 'groupBox[]', this.checked)" />
+							<input type="checkbox" name="checkme" id="checkme" onclick="checkDelBoxes(this.form, '{$input['name']}[]', this.checked)" />
 						</span>
 					</th>
 					<th class="fixed-width-xs"><span class="title_box">{l s='ID'}</span></th>
 					<th>
 						<span class="title_box">
-							{l s='Group name'}
+							{if isset($input['groups_title']) && $input['groups_title']}{$input['groups_title']}{else}{l s='Group name'}{/if}
 						</span>
 					</th>
 				</tr>
@@ -46,8 +46,8 @@
 			{foreach $groups as $key => $group}
 				<tr>
 					<td>
-						{assign var=id_checkbox value=groupBox|cat:'_'|cat:$group['id_group']}
-						<input type="checkbox" name="groupBox[]" class="groupBox" id="{$id_checkbox}" value="{$group['id_group']}" {if $fields_value[$id_checkbox]}checked="checked"{/if} />
+						{assign var=id_checkbox value=$input['name']|cat:'_'|cat:$group['id_group']}
+						<input type="checkbox" name="{$input['name']}[]" class="groupBox" id="{$id_checkbox}" value="{$group['id_group']}" {if $fields_value[$id_checkbox]}checked="checked"{/if} />
 					</td>
 					<td>{$group['id_group']}</td>
 					<td>

--- a/admin/themes/default/template/helpers/form/form_group.tpl
+++ b/admin/themes/default/template/helpers/form/form_group.tpl
@@ -34,7 +34,11 @@
 							<input type="checkbox" name="checkme" id="checkme" onclick="checkDelBoxes(this.form, '{$input['name']}[]', this.checked)" />
 						</span>
 					</th>
-					<th class="fixed-width-xs"><span class="title_box">{l s='ID'}</span></th>
+					<th class="fixed-width-xs">
+						<span class="title_box">
+							{if isset($input['groups_id_title']) && $input['groups_id_title']}{$input['groups_id_title']}{else}{l s='ID'}{/if}
+						</span>
+					</th>
 					<th>
 						<span class="title_box">
 							{if isset($input['groups_title']) && $input['groups_title']}{$input['groups_title']}{else}{l s='Group name'}{/if}


### PR DESCRIPTION
HelperForm 'group' field now allows to change the submit name and group title.