### PR TITLE
Replace 'shop' and 'shopping' with 'website' and 'booking' in email templates

### DIFF
--- a/mails/en/account.html
+++ b/mails/en/account.html
@@ -129,7 +129,7 @@
 <tr>
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
-			<span>You can now place orders on our shop: <a href="{shop_url}" style="color:#337ff1">{shop_name}</a></span>
+			<span>You can now place orders on our website: <a href="{shop_url}" style="color:#337ff1">{shop_name}</a></span>
 		</font>
 	</td>
 </tr>

--- a/mails/en/account.txt
+++ b/mails/en/account.txt
@@ -22,7 +22,7 @@ Important Security Tips:
 * Should you suspect someone is using your account illegally, please
 notify us immediately.
 
-You can now place orders on our shop: {shop_name} [/{shop_url}] 
+You can now place orders on our website: {shop_name} [/{shop_url}] 
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com] 

--- a/mails/en/awaiting_payment.html
+++ b/mails/en/awaiting_payment.html
@@ -71,7 +71,7 @@
 	<td align="center" class="titleblock" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span class="title" style="font-weight:500;font-size:28px;text-transform:uppercase;line-height:33px">Hi {firstname} {lastname},</span><br/>
-			<span class="subtitle" style="font-weight:500;font-size:16px;text-transform:uppercase;line-height:25px">Thank you for shopping with {shop_name}!</span>
+			<span class="subtitle" style="font-weight:500;font-size:16px;text-transform:uppercase;line-height:25px">Thank you for booking with {shop_name}!</span>
 		</font>
 	</td>
 </tr>
@@ -105,7 +105,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our shop.			</span>
+				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our website.			</span>
 		</font>
 	</td>
 </tr>
@@ -113,7 +113,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" style="color:#337ff1">"Guest Tracking"</a> section on our shop.			</span>
+				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" style="color:#337ff1">"Guest Tracking"</a> section on our website.			</span>
 		</font>
 	</td>
 </tr>

--- a/mails/en/awaiting_payment.txt
+++ b/mails/en/awaiting_payment.txt
@@ -3,7 +3,7 @@
 
 Hi {firstname} {lastname},
 
-Thank you for shopping with {shop_name}!
+Thank you for booking with {shop_name}!
 
 Order {order_name} - Awaiting payment
 Order reference: {order_name}
@@ -13,10 +13,10 @@ Payment method: {payment_method}
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop.
+clicking "My account" [/{my_account_url}] on our website.
 
 If you have a guest account, you can follow your order via the
-"Guest Tracking" [/{guest_tracking_url}] section on our shop.
+"Guest Tracking" [/{guest_tracking_url}] section on our website.
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com]

--- a/mails/en/credit_slip.html
+++ b/mails/en/credit_slip.html
@@ -102,7 +102,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				You can review this credit slip and download your invoice from the <a href="{credit_slip_url}" style="color:#337ff1">"My credit slips"</a> section of your account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our shop.			</span>
+				You can review this credit slip and download your invoice from the <a href="{credit_slip_url}" style="color:#337ff1">"My credit slips"</a> section of your account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our website.			</span>
 		</font>
 	</td>
 </tr>

--- a/mails/en/credit_slip.txt
+++ b/mails/en/credit_slip.txt
@@ -8,7 +8,7 @@ reference {order_name}.
 
 You can review this credit slip and download your invoice from the
 "My credit slips" [/{credit_slip_url}] section of your account by clicking
-"My account" [/{my_account_url}] on our shop. 
+"My account" [/{my_account_url}] on our website. 
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com] 

--- a/mails/en/download_product.html
+++ b/mails/en/download_product.html
@@ -105,7 +105,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our shop.			</span>
+				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our website.			</span>
 		</font>
 	</td>
 </tr>
@@ -113,7 +113,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our shop.			</span>
+				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our website.			</span>
 		</font>
 	</td>
 </tr>

--- a/mails/en/download_product.txt
+++ b/mails/en/download_product.txt
@@ -13,11 +13,11 @@ following link(s):
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop. 
+clicking "My account" [/{my_account_url}] on our website. 
 
 If you have a guest account, you can follow your order via the
 "Guest Tracking" [/{guest_tracking_url}?id_order={order_name}] section
-on our shop. 
+on our website. 
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com] 

--- a/mails/en/guest_to_customer.html
+++ b/mails/en/guest_to_customer.html
@@ -113,7 +113,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				You can access your customer account on our shop: <strong>{shop_url}</strong>
+				You can access your customer account on our website: <strong>{shop_url}</strong>
 			</span>
 		</font>
 	</td>

--- a/mails/en/guest_to_customer.txt
+++ b/mails/en/guest_to_customer.txt
@@ -12,7 +12,7 @@ PASSWORD: {passwd}
 
 Please be careful when sharing these login details with others. 
 
-You can access your customer account on our shop: {shop_url} 
+You can access your customer account on our website: {shop_url} 
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com] 

--- a/mails/en/in_transit.html
+++ b/mails/en/in_transit.html
@@ -104,7 +104,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our shop.			</span>
+				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our website.			</span>
 		</font>
 	</td>
 </tr>
@@ -112,7 +112,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our shop.			</span>
+				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our website.			</span>
 		</font>
 	</td>
 </tr>

--- a/mails/en/in_transit.txt
+++ b/mails/en/in_transit.txt
@@ -10,11 +10,11 @@ You can track your package using the following link: {followup}
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop. 
+clicking "My account" [/{my_account_url}] on our website. 
 
 If you have a guest account, you can follow your order via the
 "Guest Tracking" [/{guest_tracking_url}?id_order={order_name}] section
-on our shop. 
+on our website. 
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com] 

--- a/mails/en/order_canceled.html
+++ b/mails/en/order_canceled.html
@@ -103,7 +103,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our shop.			</span>
+				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our website.			</span>
 		</font>
 	</td>
 </tr>
@@ -111,7 +111,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our shop.			</span>
+				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our website.			</span>
 		</font>
 	</td>
 </tr>

--- a/mails/en/order_canceled.txt
+++ b/mails/en/order_canceled.txt
@@ -10,11 +10,11 @@ been canceled.
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop.
+clicking "My account" [/{my_account_url}] on our website.
 
 If you have a guest account, you can follow your order via the
 "Guest Tracking" [/{guest_tracking_url}?id_order={order_name}] section
-on our shop.
+on our website.
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com]

--- a/mails/en/order_changed.html
+++ b/mails/en/order_changed.html
@@ -102,7 +102,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our shop.			</span>
+				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our website.			</span>
 		</font>
 	</td>
 </tr>
@@ -110,7 +110,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our shop.			</span>
+				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our website.			</span>
 		</font>
 	</td>
 </tr>

--- a/mails/en/order_changed.txt
+++ b/mails/en/order_changed.txt
@@ -8,11 +8,11 @@ been changed by the merchant.
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop. 
+clicking "My account" [/{my_account_url}] on our website. 
 
 If you have a guest account, you can follow your order via the
 "Guest Tracking" [/{guest_tracking_url}?id_order={order_name}] section
-on our shop. 
+on our website. 
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com] 

--- a/mails/en/order_conf.html
+++ b/mails/en/order_conf.html
@@ -322,7 +322,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our shop.			</span>
+				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our website.			</span>
 		</font>
 	</td>
 </tr>
@@ -330,7 +330,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our shop.</span>
+				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our website.</span>
 		</font>
 	</td>
 </tr>

--- a/mails/en/order_conf.txt
+++ b/mails/en/order_conf.txt
@@ -43,12 +43,12 @@ Customer address
 You can review your order and download your invoice from the
 "Order history" [{history_url}] section of your
 customer account by clicking "My account"
-[{my_account_url}] on our shop.
+[{my_account_url}] on our website.
 
 If you have a guest account, you can follow your order via the
 "Guest Tracking"
 [{guest_tracking_url}?id_order={order_name}] section
-on our shop.
+on our website.
 
 {shop_name} [{shop_url}] powered by
 Webkul(tm) [https://webkul.com]

--- a/mails/en/order_return_state.html
+++ b/mails/en/order_return_state.html
@@ -104,7 +104,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our shop.			</span>
+				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our website.			</span>
 		</font>
 	</td>
 </tr>

--- a/mails/en/order_return_state.txt
+++ b/mails/en/order_return_state.txt
@@ -10,7 +10,7 @@ new status is: "{state_order_return}"
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop.
+clicking "My account" [/{my_account_url}] on our website.
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com]

--- a/mails/en/password.html
+++ b/mails/en/password.html
@@ -104,7 +104,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our shop.			</span>
+				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our website.			</span>
 		</font>
 	</td>
 </tr>
@@ -112,7 +112,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our shop.			</span>
+				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our website.			</span>
 		</font>
 	</td>
 </tr>

--- a/mails/en/password.txt
+++ b/mails/en/password.txt
@@ -9,11 +9,11 @@ PASSWORD: {passwd}
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop. 
+clicking "My account" [/{my_account_url}] on our website. 
 
 If you have a guest account, you can follow your order via the
 "Guest Tracking" [/{guest_tracking_url}?id_order={order_name}] section
-on our shop. 
+on our website. 
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com] 

--- a/mails/en/payment_accepted.html
+++ b/mails/en/payment_accepted.html
@@ -71,7 +71,7 @@
 	<td align="center" class="titleblock" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span class="title" style="font-weight:500;font-size:28px;text-transform:uppercase;line-height:33px">Hi {firstname} {lastname},</span><br/>
-			<span class="subtitle" style="font-weight:500;font-size:16px;text-transform:uppercase;line-height:25px">Thank you for shopping with {shop_name}!</span>
+			<span class="subtitle" style="font-weight:500;font-size:16px;text-transform:uppercase;line-height:25px">Thank you for booking with {shop_name}!</span>
 		</font>
 	</td>
 </tr>
@@ -104,7 +104,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our shop.			</span>
+				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our website.			</span>
 		</font>
 	</td>
 </tr>
@@ -112,7 +112,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our shop.			</span>
+				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our website.			</span>
 		</font>
 	</td>
 </tr>

--- a/mails/en/payment_accepted.txt
+++ b/mails/en/payment_accepted.txt
@@ -3,7 +3,7 @@
 
 Hi {firstname} {lastname},
 
-Thank you for shopping with {shop_name}!
+Thank you for booking with {shop_name}!
 
 Your payment for order with the reference {order_name} was
 successfully processed.
@@ -12,11 +12,11 @@ successfully processed.
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop.
+clicking "My account" [/{my_account_url}] on our website.
 
 If you have a guest account, you can follow your order via the
 "Guest Tracking" [/{guest_tracking_url}?id_order={order_name}] section
-on our shop.
+on our website.
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com]

--- a/mails/en/payment_error.html
+++ b/mails/en/payment_error.html
@@ -105,7 +105,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our shop.			</span>
+				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our website.			</span>
 		</font>
 	</td>
 </tr>
@@ -113,7 +113,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our shop.			</span>
+				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our website.			</span>
 		</font>
 	</td>
 </tr>

--- a/mails/en/payment_error.txt
+++ b/mails/en/payment_error.txt
@@ -13,11 +13,11 @@ WE CANNOT SHIP YOUR ORDER UNTIL WE RECEIVE YOUR PAYMENT.
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop.
+clicking "My account" [/{my_account_url}] on our website.
 
 If you have a guest account, you can follow your order via the
 "Guest Tracking" [/{guest_tracking_url}?id_order={order_name}] section
-on our shop.
+on our website.
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com]

--- a/mails/en/processing.html
+++ b/mails/en/processing.html
@@ -103,7 +103,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our shop.			</span>
+				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our website.			</span>
 		</font>
 	</td>
 </tr>
@@ -111,7 +111,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our shop.			</span>
+				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our website.			</span>
 		</font>
 	</td>
 </tr>

--- a/mails/en/processing.txt
+++ b/mails/en/processing.txt
@@ -10,11 +10,11 @@ reference {order_name}.
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop.
+clicking "My account" [/{my_account_url}] on our website.
 
 If you have a guest account, you can follow your order via the
 "Guest Tracking" [/{guest_tracking_url}?id_order={order_name}] section
-on our shop.
+on our website.
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com]

--- a/mails/en/refund.html
+++ b/mails/en/refund.html
@@ -103,7 +103,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our shop.			</span>
+				You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our website.			</span>
 		</font>
 	</td>
 </tr>
@@ -111,7 +111,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our shop.			</span>
+				If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}" style="color:#337ff1">"Guest Tracking"</a> section on our website.			</span>
 		</font>
 	</td>
 </tr>

--- a/mails/en/refund.txt
+++ b/mails/en/refund.txt
@@ -10,11 +10,11 @@ reference {order_name}.
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop.
+clicking "My account" [/{my_account_url}] on our website.
 
 If you have a guest account, you can follow your order via the
 "Guest Tracking" [/{guest_tracking_url}?id_order={order_name}] section
-on our shop.
+on our website.
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com]

--- a/mails/en/shipped.html
+++ b/mails/en/shipped.html
@@ -89,7 +89,7 @@
 							Order {order_name}&nbsp;-&nbsp;Shipped						</p>
 						<span style="color:#777">
 							Your order with the reference <span style="color:#333"><strong>{order_name}</strong></span> has been shipped.<br /> 
-							Thank you for shopping with {shop_name}!						</span>
+							Thank you for booking with {shop_name}!						</span>
 					</font>
 				</td>
 				<td width="10" style="padding:7px 0">&nbsp;</td>
@@ -100,7 +100,7 @@
 <tr>
 	<td class="linkbelow" style="padding:7px 0">
 		<span>
-			You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our shop.		</span>
+			You can review your order and download your invoice from the <a href="{history_url}" style="color:#337ff1">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}" style="color:#337ff1">"My account"</a> on our website.		</span>
 	</td>
 </tr>
 

--- a/mails/en/shipped.txt
+++ b/mails/en/shipped.txt
@@ -7,11 +7,11 @@ Your order has been shipped
 
 Your order with the reference {order_name} has been shipped.
 
-Thank you for shopping with {shop_name}! 		 
+Thank you for booking with {shop_name}! 		 
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop. 
+clicking "My account" [/{my_account_url}] on our website. 
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com] 

--- a/mails/en/test.html
+++ b/mails/en/test.html
@@ -78,7 +78,7 @@
 <tr>
 	<td class="linkbelow" style="padding:7px 0">
 		<span>
-			This is a <strong>test e-mail</strong> from your shop.<br /><br /> If you can read this, the test was successful!.
+			This is a <strong>test e-mail</strong> from your website.<br /><br /> If you can read this, the test was successful!.
 		</span>
 	</td>
 </tr>

--- a/mails/en/test.txt
+++ b/mails/en/test.txt
@@ -3,7 +3,7 @@
 
 Hello 
 
-This is a TEST E-MAIL from your shop.
+This is a TEST E-MAIL from your website.
 
 If you can read this, the test was successful!. 
 

--- a/modules/qlohotelreview/mails/en/review_approve.txt
+++ b/modules/qlohotelreview/mails/en/review_approve.txt
@@ -13,10 +13,10 @@ You can view your review from "here" [/{review_view_url}].
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop.
+clicking "My account" [/{my_account_url}] on our website.
 
 If you have a guest account, you can follow your order via the
-"Guest Tracking" [/{guest_tracking_url}] section on our shop.
+"Guest Tracking" [/{guest_tracking_url}] section on our website.
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com]

--- a/modules/qlohotelreview/mails/en/review_reply_with_link.txt
+++ b/modules/qlohotelreview/mails/en/review_reply_with_link.txt
@@ -15,10 +15,10 @@ You can view your review from "here" [/{review_view_url}].
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop.
+clicking "My account" [/{my_account_url}] on our website.
 
 If you have a guest account, you can follow your order via the
-"Guest Tracking" [/{guest_tracking_url}] section on our shop.
+"Guest Tracking" [/{guest_tracking_url}] section on our website.
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com]

--- a/modules/qlohotelreview/mails/en/review_reply_without_link.txt
+++ b/modules/qlohotelreview/mails/en/review_reply_without_link.txt
@@ -13,10 +13,10 @@ Management reply:: {management_reply}
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop.
+clicking "My account" [/{my_account_url}] on our website.
 
 If you have a guest account, you can follow your order via the
-"Guest Tracking" [/{guest_tracking_url}] section on our shop.
+"Guest Tracking" [/{guest_tracking_url}] section on our website.
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com]

--- a/modules/qlohotelreview/mails/en/review_request.txt
+++ b/modules/qlohotelreview/mails/en/review_request.txt
@@ -12,10 +12,10 @@ We love to hear your feedback and use it to improve our services!
 
 You can review your order and download your invoice from the
 "Order history" [/{history_url}] section of your customer account by
-clicking "My account" [/{my_account_url}] on our shop.
+clicking "My account" [/{my_account_url}] on our website.
 
 If you have a guest account, you can follow your order via the
-"Guest Tracking" [/{guest_tracking_url}] section on our shop.
+"Guest Tracking" [/{guest_tracking_url}] section on our website.
 
 {shop_name} [/{shop_url}] powered by Webkul(tm)
 [https://webkul.com]


### PR DESCRIPTION
Email templates have been updated to remove 'shop' and 'shopping'.