### PR TITLE
Make Our Rooms images on landing page clickable to open room type detail page

### DIFF
--- a/modules/wkhotelroom/views/templates/hook/hotelRoomDisplayBlock.tpl
+++ b/modules/wkhotelroom/views/templates/hook/hotelRoomDisplayBlock.tpl
@@ -37,7 +37,9 @@
                             <div class="row">
                         {/if}
                                 <div class="col-sm-12 col-md-6 margin-btm-30">
-                                    <img src="{$roomDisplay.image|escape:'htmlall':'UTF-8'}" alt="{$roomDisplay.name|escape:'htmlall':'UTF-8'}" class="img-responsive width-100">
+                                    <a href="{$link->getProductLink($roomDisplay.id_product)|escape:'html':'UTF-8'}">
+                                        <img src="{$roomDisplay.image|escape:'htmlall':'UTF-8'}" alt="{$roomDisplay.name|escape:'htmlall':'UTF-8'}" class="img-responsive width-100">
+                                    </a>
                                     {hook h='displayHotelRoomsBlockImageAfter' room_type=$roomDisplay}
                                     <div class="hotelRoomDescContainer">
                                         <div class="row margin-lr-0">


### PR DESCRIPTION
The images in Our Rooms block can now be clicked to go the room type detail page.