### PR TITLE
Fixed: Admin is unable to set empty birthday for a customer during update

### DIFF
--- a/controllers/admin/AdminCustomersController.php
+++ b/controllers/admin/AdminCustomersController.php
@@ -966,6 +966,21 @@ class AdminCustomersControllerCore extends AdminController
         return parent::processSave();
     }
 
+    protected function copyFromPost(&$object, $table)
+    {
+        parent::copyFromPost($object, $table);
+
+        $years = Tools::getValue('years');
+        $months = Tools::getValue('months');
+        $days = Tools::getValue('days');
+
+        if ($years != '' && $months != '' && $days != '') {
+            $object->birthday = (int) $years.'-'.(int) $months.'-'.(int) $days;
+        } elseif ($years == '' && $months == '' && $days == '') {
+            $object->birthday = null;
+        }
+    }
+
     protected function afterDelete($object, $old_id)
     {
         $customer = new Customer($old_id);

--- a/controllers/admin/AdminCustomersController.php
+++ b/controllers/admin/AdminCustomersController.php
@@ -976,8 +976,8 @@ class AdminCustomersControllerCore extends AdminController
 
         if ($years != '' && $months != '' && $days != '') {
             $object->birthday = (int) $years.'-'.(int) $months.'-'.(int) $days;
-        } elseif ($years == '' && $months == '' && $days == '') {
-            $object->birthday = null;
+        } else {
+            $object->birthday = '0000-00-00';
         }
     }
 


### PR DESCRIPTION
Admin will now be able to set customer birthday to empty when updating customer details.