### PR TITLE
Fixed: Buttons positioning issue on search results page at front office due to long length of button texts in certain languages

### DIFF
--- a/themes/hotel-reservation-theme/_partials/room_type_list.tpl
+++ b/themes/hotel-reservation-theme/_partials/room_type_list.tpl
@@ -71,10 +71,10 @@
 							</div>
 						</div>
 						<div class="row">
-							<div class="visible-md visible-lg">
+							<div class="col-sm-12 col-md-6 col-lg-4 visible-md visible-lg">
 								<div class="capa_txt"><span>{$room_v['max_guests']|escape:'htmlall':'UTF-8'} {l s='Max guests:'}</span><br><span class="capa_data"> {$room_v['max_adults']|escape:'htmlall':'UTF-8'} {l s='Adults'}, {$room_v['max_children']|escape:'htmlall':'UTF-8'} {if $room_v['children'] > 1}{l s='Children'}{else}{l s='Child'}{/if}</span></div>
 							</div>
-							<div class="col-sm-12 col-md-8 col-lg-9">
+							<div class="col-sm-12 col-md-6 col-lg-8">
 								<div class="booking_room_fields">
 									{if !isset($restricted_country_mode) && !$PS_CATALOG_MODE && !$order_date_restrict}
 										{if isset($occupancy_required_for_booking) && $occupancy_required_for_booking}

--- a/themes/hotel-reservation-theme/css/global.css
+++ b/themes/hotel-reservation-theme/css/global.css
@@ -6540,6 +6540,7 @@ table.table_block td {
 }
 .input-occupancy, .form-control .input-occupancy {
   text-align: left;
+  overflow: hidden;
 }
 
 .page-product-box {


### PR DESCRIPTION
If 'Occupancy' and 'Book Now' buttons have large texts in other languages the buttons get misplaced.