### PR TITLE
Fixed: Employee form language memorization (Administration > Employees) not working for some forms

### DIFF
--- a/modules/hotelreservationsystem/controllers/admin/AdminAddHotelController.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminAddHotelController.php
@@ -112,7 +112,8 @@ class AdminAddHotelController extends ModuleAdminController
         $smartyVars['lang'] = true;
         $smartyVars['iso'] = $this->context->language->iso_code;
         //lang vars
-        $currentLangId = Configuration::get('PS_LANG_DEFAULT');
+
+        $currentLangId = $this->default_form_language ? $this->default_form_language : Configuration::get('PS_LANG_DEFAULT');
         $smartyVars['languages'] = Language::getLanguages(false);
         $smartyVars['currentLang'] = Language::getLanguage((int) $currentLangId);
 

--- a/modules/hotelreservationsystem/controllers/admin/AdminHotelFeaturePricesSettings.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminHotelFeaturePricesSettings.php
@@ -197,7 +197,7 @@ class AdminHotelFeaturePricesSettingsController extends ModuleAdminController
         $currencySign = $objCurrency->sign;
         $dateFrom = date('d-m-Y');
         $dateTo = date('d-m-Y', strtotime($dateFrom) + 86400);
-        $currentLangId = Configuration::get('PS_LANG_DEFAULT');
+        $currentLangId = $this->default_form_language ? $this->default_form_language : Configuration::get('PS_LANG_DEFAULT');
 
         $smartyVars['languages'] = Language::getLanguages(false);
         $smartyVars['currentLang'] = Language::getLanguage((int) $currentLangId);

--- a/modules/hotelreservationsystem/controllers/admin/AdminHotelfeaturesController.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminHotelfeaturesController.php
@@ -61,7 +61,7 @@ class AdminHotelFeaturesController extends ModuleAdminController
         $smartyVars = array();
         //lang vars
         $languages = Language::getLanguages(false);
-        $currentLangId = Configuration::get('PS_LANG_DEFAULT');
+        $currentLangId = $this->default_form_language ? $this->default_form_language : Configuration::get('PS_LANG_DEFAULT');
         $currentLang = Language::getLanguage((int) $currentLangId);
         $smartyVars['languages'] = $languages;
         $smartyVars['currentLang'] = $currentLang;

--- a/modules/hotelreservationsystem/controllers/admin/AdminOrderRefundRulesController.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminOrderRefundRulesController.php
@@ -152,7 +152,7 @@ class AdminOrderRefundRulesController extends ModuleAdminController
         }
 
         //lang vars
-        $currentLangId = Configuration::get('PS_LANG_DEFAULT');
+        $currentLangId = $this->default_form_language ? $this->default_form_language : Configuration::get('PS_LANG_DEFAULT');
         $smartyVars['languages'] = Language::getLanguages(false);
         $smartyVars['currentLang'] = Language::getLanguage((int) $currentLangId);
 

--- a/modules/hotelreservationsystem/controllers/admin/AdminRoomTypeGlobalDemand.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminRoomTypeGlobalDemand.php
@@ -151,7 +151,7 @@ class AdminRoomTypeGlobalDemandController extends ModuleAdminController
         $smartyVars = array();
         $objCurrency = new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
         $smartyVars['defaultcurrencySign'] = $objCurrency->sign;
-        $currentLangId = Configuration::get('PS_LANG_DEFAULT');
+        $currentLangId = $this->default_form_language ? $this->default_form_language : Configuration::get('PS_LANG_DEFAULT');
         $languages = Language::getLanguages(false);
         $smartyVars['languages'] = $languages;
         $currentLang = Language::getLanguage((int) $currentLangId);

--- a/modules/hotelreservationsystem/views/js/HotelReservationAdmin.js
+++ b/modules/hotelreservationsystem/views/js/HotelReservationAdmin.js
@@ -767,6 +767,13 @@ function showLangField(select_lang_name, id_lang)
 
     $('.all_lang_icon').attr('src', img_dir_l+id_lang+'.jpg');
     $('#choosedLangId').val(id_lang);
+
+    var id_old_language = id_language;
+    id_language = id_lang;
+
+    if (id_old_language != id_lang) {
+        changeEmployeeLanguage();
+    }
 }
 
 /* ----  HotelConfigurationSettingController Admin ---- */

--- a/modules/hotelreservationsystem/views/templates/admin/add_hotel/helpers/form/form.tpl
+++ b/modules/hotelreservationsystem/views/templates/admin/add_hotel/helpers/form/form.tpl
@@ -483,6 +483,9 @@
 
 {block name=script}
 <script type="text/javascript">
+	var id_language = {$defaultFormLanguage|intval};
+	allowEmployeeFormLang = {$allowEmployeeFormLang|intval};
+
 	// for tiny mce setup
 	var iso = "{$iso|escape:'htmlall':'UTF-8'}";
 	var pathCSS = "{$smarty.const._THEME_CSS_DIR_|escape:'htmlall':'UTF-8'}";

--- a/modules/hotelreservationsystem/views/templates/admin/hotel_feature_prices_settings/helpers/form/form.tpl
+++ b/modules/hotelreservationsystem/views/templates/admin/hotel_feature_prices_settings/helpers/form/form.tpl
@@ -324,3 +324,10 @@
 	{addJsDef defaultcurrency_sign = $defaultcurrency_sign mod='hotelreservationsystem'}
 	{addJsDef booking_date_from = $date_from mod='hotelreservationsystem'}
 {/strip}
+
+{block name=script}
+	<script type="text/javascript">
+		var id_language = {$defaultFormLanguage|intval};
+		allowEmployeeFormLang = {$allowEmployeeFormLang|intval};
+	</script>
+{/block}

--- a/modules/hotelreservationsystem/views/templates/admin/hotel_features/helpers/form/form.tpl
+++ b/modules/hotelreservationsystem/views/templates/admin/hotel_features/helpers/form/form.tpl
@@ -133,3 +133,10 @@
 	{addJsDefL name=chld_ftr_text_err}{l s='Enter child feature name.' js=1 mod='hotelreservationsystem'}{/addJsDefL}
 	{addJsDefL name=pos_numeric_err}{l s='Position should be numeric.' js=1 mod='hotelreservationsystem'}{/addJsDefL}
 {/strip}
+
+{block name=script}
+	<script type="text/javascript">
+		var id_language = {$defaultFormLanguage|intval};
+		allowEmployeeFormLang = {$allowEmployeeFormLang|intval};
+	</script>
+{/block}

--- a/modules/hotelreservationsystem/views/templates/admin/order_refund_rules/helpers/form/form.tpl
+++ b/modules/hotelreservationsystem/views/templates/admin/order_refund_rules/helpers/form/form.tpl
@@ -133,3 +133,10 @@
 		</div>
 	</form>
 </div>
+
+{block name=script}
+	<script type="text/javascript">
+		var id_language = {$defaultFormLanguage|intval};
+		allowEmployeeFormLang = {$allowEmployeeFormLang|intval};
+	</script>
+{/block}

--- a/modules/hotelreservationsystem/views/templates/admin/room_type_global_demand/helpers/form/form.tpl
+++ b/modules/hotelreservationsystem/views/templates/admin/room_type_global_demand/helpers/form/form.tpl
@@ -275,3 +275,10 @@
 		</div>
 	</form>
 </div>
+
+{block name=script}
+	<script type="text/javascript">
+		var id_language = {$defaultFormLanguage|intval};
+		allowEmployeeFormLang = {$allowEmployeeFormLang|intval};
+	</script>
+{/block}


### PR DESCRIPTION
Fixed this issue for following forms:
1. Manage Hotel
2. Advanced Price Rules
3. Hotel Features
4. Hotel Order Refund Rules
5. Additional Facilities