### PR TITLE
Fixed: Calendar tooltips reappear on admin book now page after adding or removing rooms from cart

### DIFF
--- a/modules/hotelreservationsystem/views/js/admin/hotel_rooms_booking.js
+++ b/modules/hotelreservationsystem/views/js/admin/hotel_rooms_booking.js
@@ -28,6 +28,8 @@ $(document).ready(function() {
                 url: rooms_booking_url,
                 method: 'POST',
                 extraParams: function() {
+                    removeInitializedTooltips();
+
                     return $.extend(
                         {
                             ajax: true,
@@ -181,6 +183,14 @@ $(document).ready(function() {
             }
         });
         calendar.render();
+    }
+
+    function removeInitializedTooltips() {
+        $('#fullcalendar a.day-info, #fullcalendar .fc-daygrid-event').each(function () {
+            if ($(this).data('ui-tooltip')) {
+                $(this).tooltip('destroy');
+            }
+        });
     }
 
     function getSearchData()


### PR DESCRIPTION
If cursor is hovered on tooltip before adding or removing rooms from cart, tooltips will reappear after room is successfully added or removed.