### PR TITLE
Updated: Front office room type page show default date according to LOS

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -327,10 +327,16 @@ class ProductControllerCore extends FrontController
 
                     if (!($date_from = Tools::getValue('date_from'))) {
                         $date_from = date('Y-m-d');
-                        $date_to = date('Y-m-d', strtotime('+1 day', strtotime($date_from)));
+                        // set date to according to los
+                        $objHotelRoomTypeRestrictionDateRange = new HotelRoomTypeRestrictionDateRange();
+                        $los = $objHotelRoomTypeRestrictionDateRange->getRoomTypeLengthOfStay($this->product->id, $date_from);
+                        $date_to = date('Y-m-d', strtotime('+'.$los['min_los'].' day', strtotime($date_from)));
                     }
                     if (!($date_to = Tools::getValue('date_to'))) {
-                        $date_to = date('Y-m-d', strtotime('+1 day', strtotime($date_from)));
+                        // set date to according to los
+                        $objHotelRoomTypeRestrictionDateRange = new HotelRoomTypeRestrictionDateRange();
+                        $los = $objHotelRoomTypeRestrictionDateRange->getRoomTypeLengthOfStay($this->product->id, $date_from);
+                        $date_to = date('Y-m-d', strtotime('+'.$los['min_los'].' day', strtotime($date_from)));
                     }
 
                     $hotel_branch_obj = new HotelBranchInformation($hotel_id);


### PR DESCRIPTION
When the Front office room type page is opened without specifying dates, the default date is now selected according to LOS restriction