### PR TITLE
Updated: When translating text in QloApps only update the fields that are changed

### DIFF
--- a/admin/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl
+++ b/admin/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl
@@ -26,6 +26,7 @@
 {extends file="helpers/view/view.tpl"}
 
 {block name="override_tpl"}
+	{include file="./translation_inputs_update.tpl"}
 	{if $mod_security_warning}
 	<div class="alert alert-warning">
 		{l s='Apache mod_security is activated on your server. This could result in some Bad Request errors'}

--- a/admin/themes/default/template/controllers/translations/helpers/view/translation_form.tpl
+++ b/admin/themes/default/template/controllers/translations/helpers/view/translation_form.tpl
@@ -26,6 +26,7 @@
 {extends file="helpers/view/view.tpl"}
 
 {block name="override_tpl"}
+	{include file="./translation_inputs_update.tpl"}
 	{if $mod_security_warning}
 	<div class="alert alert-warning">
 		{l s='Apache mod_security is activated on your server. This could result in some Bad Request errors'}

--- a/admin/themes/default/template/controllers/translations/helpers/view/translation_inputs_update.tpl
+++ b/admin/themes/default/template/controllers/translations/helpers/view/translation_inputs_update.tpl
@@ -1,0 +1,31 @@
+{**
+ * 2010-2023 Webkul.
+ *
+ * NOTICE OF LICENSE
+ *
+ * All right is reserved,
+ * Please go through LICENSE.txt file inside our module
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please refer to CustomizationPolicy.txt file inside our module for more information.
+ *
+ * @author Webkul IN
+ * @copyright 2010-2023 Webkul IN
+ * @license LICENSE.txt
+ *}
+
+<script type="text/javascript">
+    $(document).ready(function(){
+        $('#translations_form input:text,textarea').each(function(){
+            $(this).data('name',$(this).attr('name'));
+            $(this).removeAttr('name');
+        });
+        $('#translations_form').on('change','input:text,textarea',function(){
+            var name = $(this).data('name');
+            if(name) $(this).attr('name',name);
+        });
+    });
+</script>

--- a/admin/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
+++ b/admin/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
@@ -26,6 +26,7 @@
 {extends file="helpers/view/view.tpl"}
 
 {block name="override_tpl"}
+	{include file="./translation_inputs_update.tpl"}
 	{if $mod_security_warning}
 	<div class="alert alert-warning">
 		{l s='Apache mod_security is activated on your server. This could result in some Bad Request errors'}

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -292,32 +292,63 @@ class AdminTranslationsControllerCore extends AdminController
             }
         }
 
-        if ($fd = fopen($file_path, 'w')) {
-            // Get value of button save and stay
-            $save_and_stay = Tools::isSubmit('submitTranslations'.$type.'AndStay');
+        // Get value of button save and stay
+        $save_and_stay = Tools::isSubmit('submitTranslations'.$type.'AndStay');
 
-            // Get language
-            $lang = strtolower(Tools::getValue('lang'));
+        // Get language
+        $lang = strtolower(Tools::getValue('lang'));
 
-            // Unset all POST which are not translations
-            unset(
-                $_POST['submitTranslations'.$type],
-                $_POST['submitTranslations'.$type.'AndStay'],
-                $_POST['lang'],
-                $_POST['token'],
-                $_POST['theme'],
-                $_POST['type']
-            );
+        // Unset all POST which are not translations
+        unset(
+            $_POST['submitTranslations'.$type],
+            $_POST['submitTranslations'.$type.'AndStay'],
+            $_POST['lang'],
+            $_POST['token'],
+            $_POST['theme'],
+            $_POST['type']
+        );
 
-            // Get all POST which aren't empty
-            $to_insert = array();
-            foreach ($_POST as $key => $value) {
-                if (!empty($value)) {
-                    $to_insert[$key] = $value;
+        // Get all POST which aren't empty
+        $to_update = array();
+        $keysToUpdate = array();
+        foreach ($_POST as $key => $value) {
+            $keysToUpdate[] = $key;
+            $to_update[$key] = $value;
+        }
+        include_once($file_path);
+        switch($this->type_selected) {
+            case 'front':
+                $to_insert = $GLOBALS['_LANG'];
+                break;
+            case 'back':
+                $to_insert = $GLOBALS['_LANGADM'];
+                break;
+            case 'errors':
+                $to_insert = $GLOBALS['_ERRORS'];
+                break;
+            case 'fields':
+                $to_insert = $GLOBALS['_FIELDS'];
+                break;
+            case 'pdf':
+                $to_insert = $GLOBALS['_LANGPDF'];
+                break;
+
+        }
+        foreach ($to_insert as $key => $value) {
+            if (in_array($key, $keysToUpdate)) {
+                if ($to_update[$key]) {
+                    $to_insert[$key] = $to_update[$key];
+                } else {
+                    unset($to_insert[$key]);
                 }
+                unset($to_update[$key]);
             }
+        }
+        foreach ($to_update as $key => $value) {
+            $to_insert[$key] = $value;
+        }
 
-            // translations array is ordered by key (easy merge)
+        if ($fd = fopen($file_path, 'w')) {
             ksort($to_insert);
             $tab = $translation_informations['var'];
             fwrite($fd, "<?php\n\nglobal \$".$tab.";\n\$".$tab." = array();\n");
@@ -929,9 +960,12 @@ class AdminTranslationsControllerCore extends AdminController
         static $cache_file = array();
         static $str_write = '';
         static $array_check_duplicate = array();
+        static $module_existing_translations = array();
 
         // Set file_name in static var, this allow to open and wright the file just one time
         if (!isset($cache_file[$theme_name.'-'.$file_name])) {
+            require $file_name;
+            $module_existing_translations = $_MODULE;
             $str_write = '';
             $cache_file[$theme_name.'-'.$file_name] = true;
             if (!Tools::file_exists_cache(dirname($file_name))) {
@@ -984,6 +1018,13 @@ class AdminTranslationsControllerCore extends AdminController
                         $this->total_expression++;
                     }
                 }
+                foreach ($module_existing_translations as $key => $value) {
+                    if (!in_array('\''.$key.'\'', $array_check_duplicate)) {
+                        $str_write .= '$_MODULE[\''.$key.'\'] = \''.pSQL(str_replace(array("\r\n", "\r", "\n"), ' ', $value)).'\';'."\n";
+
+                    }
+                }
+
             }
         }
 


### PR DESCRIPTION
When using admin translation, The while page fields are sent in post even when a single text is updated, In this PR only changed fields will be sent in post and only those fields will be updated in translation files