### PR TITLE
Fixed: Invalid tax details in invoice and credit slips

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2534,12 +2534,12 @@ class OrderCore extends ObjectModel
             $order_ecotax_tax = Tools::ps_round($order_ecotax_tax, _PS_PRICE_COMPUTE_PRECISION_, $this->round_mode);
 
             $tax_rounding_error = $expected_total_tax - $actual_total_tax - $order_ecotax_tax;
-            if ($tax_rounding_error !== 0) {
+            if ($tax_rounding_error != 0) {
                 Tools::spreadAmount($tax_rounding_error, _PS_PRICE_COMPUTE_PRECISION_, $order_detail_tax_rows, 'total_amount');
             }
 
             $base_rounding_error = $expected_total_base - $actual_total_base;
-            if ($base_rounding_error !== 0) {
+            if ($base_rounding_error != 0) {
                 Tools::spreadAmount($base_rounding_error, _PS_PRICE_COMPUTE_PRECISION_, $order_detail_tax_rows, 'total_tax_base');
             }
         }

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -443,23 +443,27 @@ class OrderInvoiceCore extends ObjectModel
             $details = $grouped_details;
         }
         foreach ($details as $row) {
-            $rate = sprintf('%.3f', $row['tax_rate']);
-            if (!isset($breakdown[$rate])) {
-                $breakdown[$rate] = array(
+            if (!$sum_composite_taxes) {
+                $key = $row['id_tax'];
+            } else {
+                $key = sprintf('%.3f', $row['tax_rate']);
+            }
+            if (!isset($breakdown[$key])) {
+                $breakdown[$key] = array(
                     'total_price_tax_excl' => 0,
                     'total_amount' => 0,
                     'id_tax' => $row['id_tax'],
-                    'rate' => $rate,
+                    'rate' => sprintf('%.3f', $row['tax_rate']),
                 );
             }
 
-            $breakdown[$rate]['total_price_tax_excl'] += $row['total_tax_base'];
-            $breakdown[$rate]['total_amount'] += $row['total_amount'];
+            $breakdown[$key]['total_price_tax_excl'] += $row['total_tax_base'];
+            $breakdown[$key]['total_amount'] += $row['total_amount'];
         }
 
-        foreach ($breakdown as $rate => $data) {
-            $breakdown[$rate]['total_price_tax_excl'] = Tools::ps_round($data['total_price_tax_excl'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
-            $breakdown[$rate]['total_amount'] = Tools::ps_round($data['total_amount'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
+        foreach ($breakdown as $key => $data) {
+            $breakdown[$key]['total_price_tax_excl'] = Tools::ps_round($data['total_price_tax_excl'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
+            $breakdown[$key]['total_amount'] = Tools::ps_round($data['total_amount'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
         }
 
         ksort($breakdown);
@@ -503,23 +507,27 @@ class OrderInvoiceCore extends ObjectModel
             $details = $grouped_details;
         }
         foreach ($details as $row) {
-            $rate = sprintf('%.3f', $row['tax_rate']);
-            if (!isset($breakdown[$rate])) {
-                $breakdown[$rate] = array(
+            if (!$sum_composite_taxes) {
+                $key = $row['id_tax'];
+            } else {
+                $key = sprintf('%.3f', $row['tax_rate']);
+            }
+            if (!isset($breakdown[$key])) {
+                $breakdown[$key] = array(
                     'total_price_tax_excl' => 0,
                     'total_amount' => 0,
                     'id_tax' => $row['id_tax'],
-                    'rate' => $rate,
+                    'rate' => sprintf('%.3f', $row['tax_rate']),
                 );
             }
 
-            $breakdown[$rate]['total_price_tax_excl'] += $row['total_tax_base'];
-            $breakdown[$rate]['total_amount'] += $row['total_amount'];
+            $breakdown[$key]['total_price_tax_excl'] += $row['total_tax_base'];
+            $breakdown[$key]['total_amount'] += $row['total_amount'];
         }
 
-        foreach ($breakdown as $rate => $data) {
-            $breakdown[$rate]['total_price_tax_excl'] = Tools::ps_round($data['total_price_tax_excl'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
-            $breakdown[$rate]['total_amount'] = Tools::ps_round($data['total_amount'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
+        foreach ($breakdown as $key => $data) {
+            $breakdown[$key]['total_price_tax_excl'] = Tools::ps_round($data['total_price_tax_excl'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
+            $breakdown[$key]['total_amount'] = Tools::ps_round($data['total_amount'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
         }
 
         ksort($breakdown);
@@ -569,23 +577,27 @@ class OrderInvoiceCore extends ObjectModel
         }
 
         foreach ($details as $row) {
-            $rate = sprintf('%.3f', $row['tax_rate']);
-            if (!isset($breakdown[$rate])) {
-                $breakdown[$rate] = array(
+            if (!$sum_composite_taxes) {
+                $key = $row['id_tax'];
+            } else {
+                $key = sprintf('%.3f', $row['tax_rate']);
+            }
+            if (!isset($breakdown[$key])) {
+                $breakdown[$key] = array(
                     'total_price_tax_excl' => 0,
                     'total_amount' => 0,
                     'id_tax' => $row['id_tax'],
-                    'rate' => $rate,
+                    'rate' => sprintf('%.3f', $row['tax_rate']),
                 );
             }
 
-            $breakdown[$rate]['total_price_tax_excl'] += $row['total_tax_base'];
-            $breakdown[$rate]['total_amount'] += $row['total_amount'];
+            $breakdown[$key]['total_price_tax_excl'] += $row['total_tax_base'];
+            $breakdown[$key]['total_amount'] += $row['total_amount'];
         }
 
-        foreach ($breakdown as $rate => $data) {
-            $breakdown[$rate]['total_price_tax_excl'] = Tools::ps_round($data['total_price_tax_excl'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
-            $breakdown[$rate]['total_amount'] = Tools::ps_round($data['total_amount'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
+        foreach ($breakdown as $key => $data) {
+            $breakdown[$key]['total_price_tax_excl'] = Tools::ps_round($data['total_price_tax_excl'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
+            $breakdown[$key]['total_amount'] = Tools::ps_round($data['total_amount'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
         }
 
         ksort($breakdown);
@@ -629,23 +641,27 @@ class OrderInvoiceCore extends ObjectModel
             $details = $grouped_details;
         }
         foreach ($details as $row) {
-            $rate = sprintf('%.3f', $row['tax_rate']);
-            if (!isset($breakdown[$rate])) {
-                $breakdown[$rate] = array(
+            if (!$sum_composite_taxes) {
+                $key = $row['id_tax'];
+            } else {
+                $key = sprintf('%.3f', $row['tax_rate']);
+            }
+            if (!isset($breakdown[$key])) {
+                $breakdown[$key] = array(
                     'total_price_tax_excl' => 0,
                     'total_amount' => 0,
                     'id_tax' => $row['id_tax'],
-                    'rate' => $rate,
+                    'rate' => $key,
                 );
             }
 
-            $breakdown[$rate]['total_price_tax_excl'] += $row['total_tax_base'];
-            $breakdown[$rate]['total_amount'] += $row['total_amount'];
+            $breakdown[$key]['total_price_tax_excl'] += $row['total_tax_base'];
+            $breakdown[$key]['total_amount'] += $row['total_amount'];
         }
 
-        foreach ($breakdown as $rate => $data) {
-            $breakdown[$rate]['total_price_tax_excl'] = Tools::ps_round($data['total_price_tax_excl'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
-            $breakdown[$rate]['total_amount'] = Tools::ps_round($data['total_amount'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
+        foreach ($breakdown as $key => $data) {
+            $breakdown[$key]['total_price_tax_excl'] = Tools::ps_round($data['total_price_tax_excl'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
+            $breakdown[$key]['total_amount'] = Tools::ps_round($data['total_amount'], _PS_PRICE_COMPUTE_PRECISION_, $order->round_mode);
         }
 
         ksort($breakdown);
@@ -693,17 +709,18 @@ class OrderInvoiceCore extends ObjectModel
             }
         } else {
             foreach ($details as $row) {
+                $key = $row['id_tax'];
                 $rate = sprintf('%.3f', $row['rate']);
-                if (!isset($breakdown[$rate])) {
-                    $breakdown[$rate] = array(
+                if (!isset($breakdown[$key])) {
+                    $breakdown[$key] = array(
                         'total_price_tax_excl' => 0,
                         'total_amount' => 0,
                         'id_tax' => $row['id_tax'],
-                        'rate' =>$rate,
+                        'rate' => $rate,
                     );
                 }
-                $breakdown[$rate]['total_price_tax_excl'] += $row['total_tax_base'];
-                $breakdown[$rate]['total_amount'] += $row['total_amount'];
+                $breakdown[$key]['total_price_tax_excl'] += $row['total_tax_base'];
+                $breakdown[$key]['total_amount'] += $row['total_amount'];
             }
         }
         foreach ($breakdown as $rate => $data) {

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -634,7 +634,6 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
             'tax_excluded_display' => $tax_excluded_display,
             'display_product_images' => $display_product_images,
             'layout' => $layout,
-            'tax_tab' => $this->getTaxTabContent(),
             'customer' => $customer,
             'footer' => $footer,
             'ps_price_compute_precision' => _PS_PRICE_COMPUTE_PRECISION_,

--- a/classes/pdf/HTMLTemplateOrderSlip.php
+++ b/classes/pdf/HTMLTemplateOrderSlip.php
@@ -200,8 +200,6 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
     {
         $address = new Address((int)$this->order->id_address_tax);
         $this->smarty->assign(array(
-            'product_tax_breakdown' => $this->getProductTaxesBreakdown(),
-            'shipping_tax_breakdown' => $this->getShippingTaxesBreakdown(),
             'order' => $this->order,
             'ecotax_tax_breakdown' => $this->order_slip->getEcoTaxTaxesBreakdown(),
             'is_order_slip' => true,
@@ -220,7 +218,7 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
     protected function getTaxBreakdown()
     {
         $breakdowns = array(
-            'product_tax' => $this->getProductTaxesBreakdown(),
+            'room_tax' => $this->getRoomTypeTaxesBreakdown(),
             'shipping_tax' => $this->getShippingTaxesBreakdown(),
             'ecotax_tax' => $this->order_slip->getEcoTaxTaxesBreakdown(),
         );
@@ -251,33 +249,78 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
         return $breakdowns;
     }
 
-    public function getProductTaxesBreakdown()
+    public function useOneAfterAnotherTaxComputationMethod()
     {
+        // if one of the order details use the tax computation method the display will be different
+        return Db::getInstance()->getValue('
+    		SELECT od.`tax_computation_method`
+    		FROM `' . _DB_PREFIX_ . 'order_detail_tax` odt
+    		LEFT JOIN `' . _DB_PREFIX_ . 'order_detail` od ON (od.`id_order_detail` = odt.`id_order_detail`)
+    		WHERE od.`id_order` = ' . (int) $this->order->id_order . '
+    		AND od.`tax_computation_method` = ' . (int) TaxCalculator::ONE_AFTER_ANOTHER_METHOD)
+            || Configuration::get('PS_INVOICE_TAXES_BREAKDOWN');
+    }
+
+    public function getRoomTypeTaxesBreakdown()
+    {
+        $sum_composite_taxes = !$this->useOneAfterAnotherTaxComputationMethod();
+
         // $breakdown will be an array with tax rates as keys and at least the columns:
         // 	- 'total_price_tax_excl'
         // 	- 'total_amount'
         $breakdown = array();
 
-        $details = $this->order->getProductTaxesDetails($this->order->products);
+        $order_detail = array_filter($this->order->products, function($v) {
+            return ($v['is_booking_product']
+                || ($v['product_auto_add']
+                    && $v['product_service_type'] == Product::SERVICE_PRODUCT_WITH_ROOMTYPE
+                    && $v['product_price_addition_type'] == ProductCore::PRICE_ADDITION_TYPE_WITH_ROOM)
+            );
+        });
+
+        $details = $this->order->getProductTaxesDetails($order_detail);
+
+        if ($sum_composite_taxes) {
+            $grouped_details = array();
+            foreach ($details as $row) {
+                if (!isset($grouped_details[$row['id_order_detail']])) {
+                    $grouped_details[$row['id_order_detail']] = array(
+                        'tax_rate' => 0,
+                        'total_tax_base' => 0,
+                        'total_amount' => 0,
+                        'id_tax' => $row['id_tax'],
+                    );
+                }
+
+                $grouped_details[$row['id_order_detail']]['tax_rate'] += $row['tax_rate'];
+                $grouped_details[$row['id_order_detail']]['total_tax_base'] += $row['total_tax_base'];
+                $grouped_details[$row['id_order_detail']]['total_amount'] += $row['total_amount'];
+            }
+            $details = $grouped_details;
+        }
 
         foreach ($details as $row) {
-            $rate = sprintf('%.3f', $row['tax_rate']);
-            if (!isset($breakdown[$rate])) {
-                $breakdown[$rate] = array(
+            if (!$sum_composite_taxes) {
+                $key = $row['id_tax'];
+            } else {
+                $key = sprintf('%.3f', $row['tax_rate']);
+            }
+            if (!isset($breakdown[$key])) {
+                $breakdown[$key] = array(
                     'total_price_tax_excl' => 0,
                     'total_amount' => 0,
                     'id_tax' => $row['id_tax'],
-                    'rate' =>$rate,
+                    'rate' => sprintf('%.3f', $row['tax_rate']),
                 );
             }
 
-            $breakdown[$rate]['total_price_tax_excl'] += $row['total_tax_base'];
-            $breakdown[$rate]['total_amount'] += $row['total_amount'];
+            $breakdown[$key]['total_price_tax_excl'] += $row['total_tax_base'];
+            $breakdown[$key]['total_amount'] += $row['total_amount'];
         }
 
-        foreach ($breakdown as $rate => $data) {
-            $breakdown[$rate]['total_price_tax_excl'] = Tools::ps_round($data['total_price_tax_excl'], _PS_PRICE_COMPUTE_PRECISION_, $this->order->round_mode);
-            $breakdown[$rate]['total_amount'] = Tools::ps_round($data['total_amount'], _PS_PRICE_COMPUTE_PRECISION_, $this->order->round_mode);
+        foreach ($breakdown as $key => $data) {
+            $breakdown[$key]['total_price_tax_excl'] = Tools::ps_round($data['total_price_tax_excl'], _PS_PRICE_COMPUTE_PRECISION_, $this->order->round_mode);
+            $breakdown[$key]['total_amount'] = Tools::ps_round($data['total_amount'], _PS_PRICE_COMPUTE_PRECISION_, $this->order->round_mode);
         }
 
         ksort($breakdown);


### PR DESCRIPTION
In order invoice and credit slip, tax was not displayed correctly when multiple taxes in tax rule are applied with combined and one after another option. 