### PR TITLE
Updated: Removed decimal values from admin stats graph axis where not required

### DIFF
--- a/classes/module/ModuleGraph.php
+++ b/classes/module/ModuleGraph.php
@@ -37,6 +37,8 @@ abstract class ModuleGraphCore extends Module
     /**@var array string graph titles */
     protected $_titles = array('main' => null, 'x' => null, 'y' => null);
 
+    protected $_formats = array('x' => null, 'y' => null);
+
     /** @var ModuleGraphEngine graph engine */
     protected $_render;
 
@@ -258,6 +260,7 @@ abstract class ModuleGraphCore extends Module
         $this->_render->setSize($width, $height);
         $this->_render->setLegend($this->_legend);
         $this->_render->setTitles($this->_titles);
+        $this->_render->setFormat($this->_formats);
     }
 
     public function draw()

--- a/modules/graphnvd3/graphnvd3.php
+++ b/modules/graphnvd3/graphnvd3.php
@@ -35,6 +35,7 @@ class GraphNvD3 extends ModuleGraphEngine
     private $_values;
     private $_legend;
     private $_titles;
+    private $_formats;
 
     public function __construct($type = null)
     {
@@ -113,6 +114,12 @@ class GraphNvD3 extends ModuleGraphEngine
 					if (jsonData.axisLabels.yAxis != null)
 						chart.yAxis.axisLabel(jsonData.axisLabels.yAxis);
 
+                    if (jsonData.axisFormat.xAxis)
+                        chart.xAxis.tickFormat(d3.format(jsonData.axisFormat.xAxis));
+                    if (jsonData.axisFormat.yAxis)
+                        chart.yAxis.tickFormat(d3.format(jsonData.axisFormat.yAxis));
+
+                        console.log(jsonData.data);
 					d3.select("#nvd3_chart_'.($divid++).' svg")
 						.datum(jsonData.data)
 						.transition().duration(500)
@@ -148,10 +155,16 @@ class GraphNvD3 extends ModuleGraphEngine
         $this->_titles = $titles;
     }
 
+    public function setFormat($_formats)
+    {
+        $this->_formats = $_formats;
+    }
+
     public function draw()
     {
         $array = array(
             'axisLabels' => array('xAxis' => $this->_titles['x'], 'yAxis' => $this->_titles['y']),
+            'axisFormat' => array('xAxis' => $this->_formats['x'], 'yAxis' => $this->_formats['y']),
             'data' => array()
         );
 

--- a/modules/graphnvd3/graphnvd3.php
+++ b/modules/graphnvd3/graphnvd3.php
@@ -118,8 +118,6 @@ class GraphNvD3 extends ModuleGraphEngine
                         chart.xAxis.tickFormat(d3.format(jsonData.axisFormat.xAxis));
                     if (jsonData.axisFormat.yAxis)
                         chart.yAxis.tickFormat(d3.format(jsonData.axisFormat.yAxis));
-
-                        console.log(jsonData.data);
 					d3.select("#nvd3_chart_'.($divid++).' svg")
 						.datum(jsonData.data)
 						.transition().duration(500)

--- a/modules/statsnewsletter/statsnewsletter.php
+++ b/modules/statsnewsletter/statsnewsletter.php
@@ -129,6 +129,7 @@ class StatsNewsletter extends ModuleGraph
         $this->_titles['main'][1] = $this->l('Visitors');
         $this->_titles['main'][2] = $this->l('Newsletter statistics');
         $this->_titles['main'][3] = $this->l('Both');
+        $this->_formats['y'] = 'd';
 
         $this->_query = 'SELECT newsletter_date_add
 				FROM `'._DB_PREFIX_.'customer`

--- a/modules/statsproduct/statsproduct.php
+++ b/modules/statsproduct/statsproduct.php
@@ -343,6 +343,7 @@ class StatsProduct extends ModuleGraph
                 $this->_titles['main'][1] = $this->l('Views (x100)');
                 $this->_titles['x'] = $this->l('Date');
                 $this->_titles['y'] = $this->l('Room nights, Views (x100)');
+                $this->_formats['y'] = 'd';
 
                 $this->query[0] = 'SELECT o.`date_add`, SUM(DATEDIFF(hbd.`date_to`, hbd.`date_from`)) AS total
                 FROM `'._DB_PREFIX_.'order_detail` od

--- a/modules/statsregistrations/statsregistrations.php
+++ b/modules/statsregistrations/statsregistrations.php
@@ -171,6 +171,7 @@ class StatsRegistrations extends ModuleGraph
 				'.Shop::addSqlRestriction(Shop::SHARE_CUSTOMER).'
 				AND `date_add` BETWEEN';
         $this->_titles['main'] = $this->l('Number of customer registrations');
+        $this->_formats['y'] = 'd';
         $this->setDateGraph($layers, true);
     }
 

--- a/modules/statssales/statssales.php
+++ b/modules/statssales/statssales.php
@@ -234,6 +234,10 @@ class StatsSales extends ModuleGraph
             return $this->getOrderStatusesData();
         }
 
+        if ($this->option == 1) {
+            $this->_formats['y'] = 'd';
+        }
+
         $this->query = 'SELECT o.`invoice_date`, ROUND(o.`total_paid_real` / o.`conversion_rate`, 2) as total_paid_real,
         (
             SELECT hbd.`id_hotel`

--- a/modules/statsvisits/statsvisits.php
+++ b/modules/statsvisits/statsvisits.php
@@ -157,6 +157,7 @@ class StatsVisits extends ModuleGraph
     protected function getData($layers)
     {
         $this->setDateGraph($layers, true);
+        $this->_formats['y'] = 'd';
     }
 
     protected function setAllTimeValues($layers)


### PR DESCRIPTION
In the admin stats page, some graphs showed values on the axis as decimal values but the value must be a whole number. Added option to provide axis value format which fixes this issue