### PR TITLE
Added: Accurate Page Name Display in Statistics by Introducing Controller Property "alias" 

### DIFF
--- a/classes/Page.php
+++ b/classes/Page.php
@@ -48,7 +48,9 @@ class PageCore extends ObjectModel
      */
     public static function getCurrentId()
     {
-        $controller = Dispatcher::getInstance()->getController();
+        if (!$controller = context::getContext()->controller->alias) {
+            $controller = Dispatcher::getInstance()->getController();
+        }
         $page_type_id = Page::getPageTypeByName($controller);
 
         // Some pages must be distinguished in order to record exactly what is being seen

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -78,6 +78,9 @@ abstract class ControllerCore
     /** @var string Controller name */
     public $php_self;
 
+    /** @var string Controller alias */
+    public $alias;
+
     /**
      * Check if the controller is available for the current user/visitor
      */

--- a/controllers/front/CategoryController.php
+++ b/controllers/front/CategoryController.php
@@ -29,6 +29,8 @@ class CategoryControllerCore extends FrontController
     /** string Internal controller name */
     public $php_self = 'category';
 
+    public $alias = 'hotel';
+
     /** @var Category Current category object */
     protected $category;
 

--- a/controllers/front/OrderOpcController.php
+++ b/controllers/front/OrderOpcController.php
@@ -27,6 +27,7 @@
 class OrderOpcControllerCore extends ParentOrderController
 {
     public $php_self = 'order-opc';
+    public $alias = 'checkout';
     public $isLogged;
 
     protected $ajax_refresh = false;

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -28,6 +28,8 @@ class ProductControllerCore extends FrontController
 {
     public $php_self = 'product';
 
+    public $alias = 'room-type';
+
     /** @var Product */
     protected $product;
 


### PR DESCRIPTION
The page name in statistics was incorrectly displayed based on the controller name. Introduced a new property in the controller class, that when set, will accurately represent the page name in statistics instead of the controller name.