### PR TITLE
Fix: Smarty index.php in smarty cache and compile directory gets deleted when clearing cache

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3023,6 +3023,8 @@ exit;
         $smarty = Context::getContext()->smarty;
         Tools::clearCache($smarty);
         Tools::clearCompile($smarty);
+        @copy(_PS_CACHE_DIR_.'smarty/index.php', _PS_CACHE_DIR_.'smarty/cache/index.php');
+        @copy(_PS_CACHE_DIR_.'smarty/index.php', _PS_CACHE_DIR_.'smarty/compile/index.php');
     }
 
     public static function clearColorListCache($id_product = false)

--- a/tools/smarty/sysplugins/smarty_internal_method_clearcompiledtemplate.php
+++ b/tools/smarty/sysplugins/smarty_internal_method_clearcompiledtemplate.php
@@ -114,11 +114,6 @@ class Smarty_Internal_Method_ClearCompiledTemplate
                         $unlink = true;
                     }
                 }
-
-                if (substr($_filepath, -9) == 'index.php') {
-                    $unlink = false;
-                }
-
                 if ($unlink && is_file($_filepath) && @unlink($_filepath)) {
                     $_count++;
                     if (function_exists('opcache_invalidate')


### PR DESCRIPTION


1. The following files gets deleted when clearing cache causing a warning on the configuration Information page.
    - '/cache/smarty/compile/index.php'
    - '/cache/smarty/cache/index.php'

2. revert changes done in Smarty library.
