### PR TITLE
Fixed: Auto added services price not showing in cart summary in admin book now page

### DIFF
--- a/modules/hotelreservationsystem/classes/HotelCartBookingData.php
+++ b/modules/hotelreservationsystem/classes/HotelCartBookingData.php
@@ -1011,6 +1011,32 @@ class HotelCartBookingData extends ObjectModel
                     false,
                     1
                 );
+                $cart_detail_data[$key]['additional_services_auto_add_with_room_price'] = $objRoomTypeServiceProductCartDetail->getServiceProductsTotalInCart(
+                    $id_cart,
+                    0,
+                    0,
+                    $value['id_product'],
+                    $value['date_from'],
+                    $value['date_to'],
+                    $value['id'],
+                    false,
+                    1,
+                    null,
+                    Product::PRICE_ADDITION_TYPE_WITH_ROOM
+                );
+                $cart_detail_data[$key]['additional_services_auto_add_independent_price'] = $objRoomTypeServiceProductCartDetail->getServiceProductsTotalInCart(
+                    $id_cart,
+                    0,
+                    0,
+                    $value['id_product'],
+                    $value['date_from'],
+                    $value['date_to'],
+                    $value['id'],
+                    false,
+                    1,
+                    null,
+                    Product::PRICE_ADDITION_TYPE_INDEPENDENT
+                );
                 // By webkul New way to calculate product prices with feature Prices
                 $roomTypeDateRangePrice = HotelRoomTypeFeaturePricing::getRoomTypeTotalPrice(
                     $value['id_product'],

--- a/modules/hotelreservationsystem/controllers/admin/AdminHotelRoomsBookingController.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminHotelRoomsBookingController.php
@@ -355,10 +355,8 @@ class AdminHotelRoomsBookingController extends ModuleAdminController
         $objHotelServiceProductCartDetail = new HotelServiceProductCartDetail();
 
         if ($cartProducts = $this->context->cart->getProducts()) {
-            if ($cart_bdata = $objHotelCartBookingData->getCartBookingDetailsByIdCartIdGuest(
-                $this->context->cart->id,
-                $this->context->cookie->id_guest,
-                $this->context->employee->id_lang
+            if ($cart_bdata = $objHotelCartBookingData->getCartFormatedBookinInfoByIdCart(
+                $this->context->cart->id
             )) {
                 $smartyVars['cart_bdata'] = $cart_bdata;
             }
@@ -371,7 +369,9 @@ class AdminHotelRoomsBookingController extends ModuleAdminController
         $smartyVars['rms_in_cart'] = $objHotelCartBookingData->getCountRoomsInCart($this->id_cart, $this->id_guest);
         $smartyVars['products_in_cart'] = $products_in_cart;
         $smartyVars['total_products_in_cart'] = (int)$rms_in_cart + (int)$products_in_cart;
-        $smartyVars['cart_tamount'] = $this->context->cart->getOrderTotal();
+        $cartAmountTotal = $this->context->cart->getOrderTotal(false);
+        $cartAmountConvenienceFee  = $this->context->cart->getOrderTotal(false, cart::ONLY_CONVENIENCE_FEE);
+        $smartyVars['cart_tamount'] = $cartAmountTotal - $cartAmountConvenienceFee;
 
         $this->context->smarty->assign($smartyVars);
     }

--- a/modules/hotelreservationsystem/views/templates/admin/hotel_rooms_booking/helpers/view/_partials/booking-cart.tpl
+++ b/modules/hotelreservationsystem/views/templates/admin/hotel_rooms_booking/helpers/view/_partials/booking-cart.tpl
@@ -27,7 +27,7 @@
 											<td class="text-center">{$cart_data['room_num']|escape:'htmlall':'UTF-8'}</td>
 											<td class="text-center">{$cart_data['room_type']|escape:'htmlall':'UTF-8'}</td>
 											<td class="text-center">{dateFormat date=$cart_data['date_from']} - {dateFormat date=$cart_data['date_to']}</td>
-											<td class="text-center">{convertPrice price=$cart_data['amt_with_qty']}</td>
+											<td class="text-center">{convertPrice price=($cart_data['amt_with_qty'] + $cart_data['additional_services_auto_add_with_room_price'] + $cart_data['additional_service_price'] + $cart_data['demand_price'])}</td>
 											<td class="text-center"><button class="btn btn-default ajax_cart_delete_data" data-id-product="{$cart_data['id_product']|escape:'htmlall':'UTF-8'}" data-id-hotel="{$cart_data['id_hotel']|escape:'htmlall':'UTF-8'}" data-id-cart="{$cart_data['id_cart']|escape:'htmlall':'UTF-8'}" data-id-cart-book-data="{$cart_data['id_cart_book_data']|escape:'htmlall':'UTF-8'}" data-date-from="{$cart_data['date_from']|escape:'htmlall':'UTF-8'}" data-date-to="{$cart_data['date_to']|escape:'htmlall':'UTF-8'}"><i class='icon-trash'></i></button></td>
 										</tr>
 									{/foreach}
@@ -54,7 +54,7 @@
                                                     <td>{$cart_data['name']|escape:'htmlall':'UTF-8'}</td>
                                                     <td>{$cart_data['hotel_name']|escape:'htmlall':'UTF-8'}</td>
                                                     <td>{$cart_data['quantity']|escape:'htmlall':'UTF-8'}</td>
-                                                    <td>{convertPrice price=$cart_data['total_price_tax_incl']}</td>
+                                                    <td>{convertPrice price=$cart_data['total_price_tax_excl']}</td>
                                                     <td><button class="btn btn-default service_product_delete" data-id-hotel="{$cart_data['id_hotel']|escape:'htmlall':'UTF-8'}" data-id-product="{$cart_data['id_product']|escape:'htmlall':'UTF-8'}" data-id-cart="{$id_cart|escape:'htmlall':'UTF-8'}"><i class='icon-trash'></i></button></td>
                                                 </tr>
                                             {/foreach}
@@ -69,7 +69,7 @@
 					<div class="row cart_amt_div">
 						<table class="table table-responsive">
 							<tr>
-								<th colspan="2">{l s='Total Amount (Tax incl.):' mod='hotelreservationsystem'}</th>
+								<th colspan="2">{l s='Total Amount (Tax excl.):' mod='hotelreservationsystem'}</th>
 								<th colspan="2" class="text-right" id="cart_total_amt">
 									{if isset($cart_tamount)}{convertPrice price=$cart_tamount}{else}{convertPrice price=0}{/if}
 								</th>


### PR DESCRIPTION
When creating an order from the Back office, Auto added services (with room type) price is not added in the room row but it is added to the Total amount (Tax included.)
Cart summary should show all prices tax excluded