### PR TITLE
Fixed: Incorrect room price and final price when admin remove service product or update room price from admin end and proceed for payment at front office

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -862,7 +862,11 @@ abstract class PaymentModuleCore extends Module
                                         $objBookingDetail->total_paid_amount = $objAdvancedPayment->getRoomMinAdvPaymentAmount(
                                             $idProduct,
                                             $objCartBookingData->date_from,
-                                            $objCartBookingData->date_to
+                                            $objCartBookingData->date_to,
+                                            1,
+                                            $objCartBookingData->id_room,
+                                            $objCartBookingData->id_cart,
+                                            $objCartBookingData->id_guest
                                         );
                                     }
                                 }
@@ -1596,13 +1600,6 @@ abstract class PaymentModuleCore extends Module
                                 $cart_htl_data[$type_key]['date_diff'][$date_join]['adults'] += $data_v['adults'];
                                 $cart_htl_data[$type_key]['date_diff'][$date_join]['children'] += $data_v['children'];
 
-
-
-
-                                $roomTypeDateRangePrice = HotelRoomTypeFeaturePricing::getRoomTypeTotalPrice($type_value['id_product'], $data_v['date_from'], $data_v['date_to']);
-
-
-                                $cart_htl_data[$type_key]['date_diff'][$date_join]['amount'] = $roomTypeDateRangePrice['total_price_tax_incl']*$vart_quant;
                                 // extra demands prices
                                 $cart_htl_data[$type_key]['date_diff'][$date_join]['extra_demands'] = $objBookingDemand->getRoomTypeBookingExtraDemands(
                                     $order->id,

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1600,6 +1600,13 @@ abstract class PaymentModuleCore extends Module
                                 $cart_htl_data[$type_key]['date_diff'][$date_join]['adults'] += $data_v['adults'];
                                 $cart_htl_data[$type_key]['date_diff'][$date_join]['children'] += $data_v['children'];
 
+
+
+
+                                $roomTypeDateRangePrice = HotelRoomTypeFeaturePricing::getRoomTypeTotalPrice($type_value['id_product'], $data_v['date_from'], $data_v['date_to']);
+
+
+                                $cart_htl_data[$type_key]['date_diff'][$date_join]['amount'] = $roomTypeDateRangePrice['total_price_tax_incl']*$vart_quant;
                                 // extra demands prices
                                 $cart_htl_data[$type_key]['date_diff'][$date_join]['extra_demands'] = $objBookingDemand->getRoomTypeBookingExtraDemands(
                                     $order->id,

--- a/modules/hotelreservationsystem/classes/HotelAdvancedPayment.php
+++ b/modules/hotelreservationsystem/classes/HotelAdvancedPayment.php
@@ -108,7 +108,13 @@ class HotelAdvancedPayment extends ObjectModel
                 $roomTotalPrices = HotelRoomTypeFeaturePricing::getRoomTypeTotalPrice(
                     $cartRoomInfo['id_product'],
                     $cartRoomInfo['date_from'],
-                    $cartRoomInfo['date_to']
+                    $cartRoomInfo['date_to'],
+                    0,
+                    0,
+                    $idCart,
+                    $cartRoomInfo['id_guest'],
+                    $cartRoomInfo['id_room'],
+                    0
                 );
 
                 $roomTypeTotalTI += $roomTotalPrices['total_price_tax_incl'];
@@ -319,7 +325,7 @@ class HotelAdvancedPayment extends ObjectModel
      * @param integer $withTaxes : Amount with(1) or without tax (0)
      * @return [float] advance payment amount of the room type in the cart
      */
-    public function getRoomMinAdvPaymentAmount($idProduct, $dateFrom, $dateTo, $withTaxes = 1)
+    public function getRoomMinAdvPaymentAmount($idProduct, $dateFrom, $dateTo, $withTaxes = 1, $idRoom = 0, $idCart = 0, $idGuest = 0)
     {
         $dateFrom = date('Y-m-d', strtotime($dateFrom));
         $dateTo = date('Y-m-d', strtotime($dateTo));
@@ -328,7 +334,17 @@ class HotelAdvancedPayment extends ObjectModel
         $advGlobalPercent = Configuration::get('WK_ADVANCED_PAYMENT_GLOBAL_MIN_AMOUNT');
         $advGlobalTaxIncl = Configuration::get('WK_ADVANCED_PAYMENT_INC_TAX');
 
-        $roomTotalPrices = HotelRoomTypeFeaturePricing::getRoomTypeTotalPrice($idProduct, $dateFrom, $dateTo);
+        $roomTotalPrices = HotelRoomTypeFeaturePricing::getRoomTypeTotalPrice(
+            $idProduct,
+            $dateFrom,
+            $dateTo,
+            0,
+            0,
+            $idCart,
+            $idGuest,
+            $idRoom,
+            0
+        );
         $roomTypeTotalTI = $roomTotalPrices['total_price_tax_incl'];
         $roomTypeTotalTE = $roomTotalPrices['total_price_tax_excl'];
 

--- a/modules/hotelreservationsystem/classes/HotelBookingDetail.php
+++ b/modules/hotelreservationsystem/classes/HotelBookingDetail.php
@@ -1947,29 +1947,6 @@ class HotelBookingDetail extends ObjectModel
                     $newTotalPriceTI = $unitRoomPriceTI * $newNumDays;
                 }
 
-                // calculate `total_paid_amount`
-                $totalPaidAmount = 0;
-                $isAdvancePayment = Db::getInstance()->getValue(
-                    'SELECT o.`is_advance_payment`
-                    FROM `'._DB_PREFIX_.'orders` o
-                    WHERE o.`id_order` = '.(int) $idOrder
-                );
-
-                if ($isAdvancePayment) {
-                    $objHotelAdvancedPayment = new HotelAdvancedPayment();
-                    $productAdvancePayment = $objHotelAdvancedPayment->getIdAdvPaymentByIdProduct($objHotelBookingDetail->id_product);
-
-                    if (!$productAdvancePayment || (isset($productAdvancePayment['payment_type']) && $productAdvancePayment['payment_type'])) {
-                        $totalPaidAmount = $objHotelAdvancedPayment->getRoomMinAdvPaymentAmount(
-                            $objHotelBookingDetail->id_product,
-                            $newDateFrom,
-                            $newDateTo
-                        );
-                    }
-                } else {
-                    $totalPaidAmount = $newTotalPriceTI;
-                }
-
                 // update $objHotelCartBookingData
                 $objHotelCartBookingData->date_from = $newDateFrom;
                 $objHotelCartBookingData->date_to = $newDateTo;
@@ -1983,7 +1960,6 @@ class HotelBookingDetail extends ObjectModel
                 $objHotelBookingDetail->date_to = $newDateTo;
                 $objHotelBookingDetail->total_price_tax_excl = Tools::ps_round($newTotalPriceTE, 6);
                 $objHotelBookingDetail->total_price_tax_incl = Tools::ps_round($newTotalPriceTI, 6);
-                $objHotelBookingDetail->total_paid_amount = Tools::ps_round($totalPaidAmount, 6);
                 $objHotelBookingDetail->adults = $occupancy['adults'];
                 $objHotelBookingDetail->children = $occupancy['children'];
                 $objHotelBookingDetail->child_ages = json_encode($occupancy['child_ages']);

--- a/modules/hotelreservationsystem/classes/HotelCartBookingData.php
+++ b/modules/hotelreservationsystem/classes/HotelCartBookingData.php
@@ -1340,7 +1340,12 @@ class HotelCartBookingData extends ObjectModel
                                     $roomTypeDateRangePrice = HotelRoomTypeFeaturePricing::getRoomTypeTotalPrice(
                                         $product['id_product'],
                                         $data_v['date_from'],
-                                        $data_v['date_to']
+                                        $data_v['date_to'],
+                                        0,
+                                        0,
+                                        $context->cart->id,
+                                        $context->cart->id_guest,
+                                        $data_v['id_room']
                                     );
                                     $roomTypeDateRangePriceWithoutAutoAdd = HotelRoomTypeFeaturePricing::getRoomTypeTotalPrice(
                                         $product['id_product'],
@@ -1348,9 +1353,9 @@ class HotelCartBookingData extends ObjectModel
                                         $data_v['date_to'],
                                         0,
                                         0,
-                                        0,
-                                        0,
-                                        0,
+                                        $context->cart->id,
+                                        $context->cart->id_guest,
+                                        $data_v['id_room'],
                                         0
                                     );
                                     if (!$price_tax) {
@@ -1382,7 +1387,12 @@ class HotelCartBookingData extends ObjectModel
                                     $roomTypeDateRangePrice = HotelRoomTypeFeaturePricing::getRoomTypeTotalPrice(
                                         $product['id_product'],
                                         $data_v['date_from'],
-                                        $data_v['date_to']
+                                        $data_v['date_to'],
+                                        0,
+                                        0,
+                                        $context->cart->id,
+                                        $context->cart->id_guest,
+                                        $data_v['id_room']
                                     );
                                     $roomTypeDateRangePriceWithoutAutoAdd = HotelRoomTypeFeaturePricing::getRoomTypeTotalPrice(
                                         $product['id_product'],
@@ -1390,9 +1400,9 @@ class HotelCartBookingData extends ObjectModel
                                         $data_v['date_to'],
                                         0,
                                         0,
-                                        0,
-                                        0,
-                                        0,
+                                        $context->cart->id,
+                                        $context->cart->id_guest,
+                                        $data_v['id_room'],
                                         0
                                     );
                                     if (!$price_tax) {

--- a/modules/hotelreservationsystem/classes/HotelRoomTypeFeaturePricing.php
+++ b/modules/hotelreservationsystem/classes/HotelRoomTypeFeaturePricing.php
@@ -719,12 +719,28 @@ class HotelRoomTypeFeaturePricing extends ObjectModel
             }
         }
         if ($with_auto_room_services) {
-            if ($servicesWithTax = RoomTypeServiceProduct::getAutoAddServices($id_product, $date_from, $date_to, Product::PRICE_ADDITION_TYPE_WITH_ROOM, true)) {
+            if ($servicesWithTax = RoomTypeServiceProduct::getAutoAddServices(
+                $id_product,
+                $date_from,
+                $date_to,
+                Product::PRICE_ADDITION_TYPE_WITH_ROOM,
+                true,
+                $id_cart,
+                $id_guest
+            )) {
                 foreach($servicesWithTax as $service) {
                     $totalPrice['total_price_tax_incl'] += $service['price'];
                 }
             }
-            if ($servicesWithoutTax = RoomTypeServiceProduct::getAutoAddServices($id_product, $date_from, $date_to, Product::PRICE_ADDITION_TYPE_WITH_ROOM, false)) {
+            if ($servicesWithoutTax = RoomTypeServiceProduct::getAutoAddServices(
+                $id_product,
+                $date_from,
+                $date_to,
+                Product::PRICE_ADDITION_TYPE_WITH_ROOM,
+                false,
+                $id_cart,
+                $id_guest
+            )) {
                 foreach($servicesWithoutTax as $service) {
                     $totalPrice['total_price_tax_excl'] += $service['price'];
                 }

--- a/modules/hotelreservationsystem/classes/RoomTypeServiceProduct.php
+++ b/modules/hotelreservationsystem/classes/RoomTypeServiceProduct.php
@@ -115,12 +115,16 @@ class RoomTypeServiceProduct extends ObjectModel
         return Db::getInstance()->getValue($sql);
     }
 
-    public static function getAutoAddServices($idProduct, $dateFrom = null, $dateTo = null, $priceAdditionType = null, $useTax = null)
+    public static function getAutoAddServices($idProduct, $dateFrom = null, $dateTo = null, $priceAdditionType = null, $useTax = null, $idCart = 0, $idGuest = 0)
     {
         if (Product::isBookingProduct($idProduct)) {
             $sql = 'SELECT p.`id_product` FROM  `'._DB_PREFIX_.'htl_room_type_service_product` rsp
-            INNER JOIN `'._DB_PREFIX_.'product` p ON (rsp.`id_product` = p.`id_product` AND p.`auto_add_to_cart` = 1)
-            WHERE p.`active` = 1 AND `id_element` = '.(int)$idProduct.' AND `element_type` = '.self::WK_ELEMENT_TYPE_ROOM_TYPE;
+            INNER JOIN `'._DB_PREFIX_.'product` p ON (rsp.`id_product` = p.`id_product` AND p.`auto_add_to_cart` = 1)';
+            if ($idCart) {
+                $sql .= ' INNER JOIN `'._DB_PREFIX_.'htl_room_type_service_product_cart_detail` spcd
+                    ON (rsp.`id_product` = spcd.`id_product` AND spcd.`id_cart` = '.(int)$idCart.')';
+            }
+            $sql .= ' WHERE p.`active` = 1 AND `id_element` = '.(int)$idProduct.' AND `element_type` = '.self::WK_ELEMENT_TYPE_ROOM_TYPE;
             if (!is_null($priceAdditionType)) {
                 $sql .= ' AND p.`price_addition_type` = '.$priceAdditionType;
             }


### PR DESCRIPTION
When auto-added servies are removed from room by admin, the room price calculation is wrong when opening cart at front end.

When admin uses a custom price when creating an order from backoffice, and cart is opened from front end and advance price is used, the advance paid price is calculated incorrect