### PR TITLE
Updated: Optimized search results in the admin search page.

### DIFF
--- a/admin/themes/default/sass/partials/_nav.sass
+++ b/admin/themes/default/sass/partials/_nav.sass
@@ -268,6 +268,11 @@ $min-height: 850px
 			width: 200px
 			@include margin-right(5px)
 			@include float(right)
+			.clear_search
+				position: absolute
+				top: 6px
+				z-index: 10
+				@include right(8px)
 		li.maintab, li.subtab
 			height: 28px
 			padding: 0

--- a/admin/themes/default/template/controllers/search/helpers/view/view.tpl
+++ b/admin/themes/default/template/controllers/search/helpers/view/view.tpl
@@ -108,43 +108,160 @@ $(function() {
 	</div>
 	{/if}
 
+	{if isset($num_hotels) && $num_hotels}
+		<div class="panel">
+			<h3>
+				{if $num_hotels == 1}
+					{l s='1 Hotel'}
+				{else}
+					{l s='%d Hotels' sprintf=$num_hotels}
+				{/if}
+			</h3>
+			{$hotels}
+		</div>
+	{/if}
+
+	{if isset($num_hotel_features) && $num_hotel_features}
+		<div class="panel">
+			<h3>
+				{if $num_hotel_features == 1}
+					{l s='1 hotel feature'}
+				{else}
+					{l s='%d hotel features' sprintf=$num_hotel_features}
+				{/if}
+			</h3>
+			{$hotel_features}
+		</div>
+	{/if}
+
 	{if isset($num_products) && $num_products}
-	<div class="panel">
-		<h3>
-			{if $num_products == 1}
-				{l s='1 product'}
-			{else}
-				{l s='%d products' sprintf=$num_products}
-			{/if}
-		</h3>
-		{$products}
-	</div>
+		<div class="panel">
+			<h3>
+				{if $num_products == 1}
+					{l s='1 room type'}
+				{else}
+					{l s='%d room types' sprintf=$num_products}
+				{/if}
+			</h3>
+			{$products}
+		</div>
+	{/if}
+
+	{if isset($num_catalog_features) && $num_catalog_features}
+		<div class="panel">
+			<h3>
+				{if $num_catalog_features == 1}
+					{l s='1 feature'}
+				{else}
+					{l s='%d features' sprintf=$num_catalog_features}
+				{/if}
+			</h3>
+			{$catalog_features}
+		</div>
+	{/if}
+
+	{if isset($num_service_products) && $num_service_products}
+		<div class="panel">
+			<h3>
+				{if $num_service_products == 1}
+					{l s='1 service product'}
+				{else}
+					{l s='%d service products' sprintf=$num_service_products}
+				{/if}
+			</h3>
+			{$service_products}
+		</div>
+	{/if}
+
+	{if isset($num_global_demands) && $num_global_demands}
+		<div class="panel">
+			<h3>
+				{if $num_global_demands == 1}
+					{l s='1 global demand'}
+				{else}
+					{l s='%d global demands' sprintf=$num_global_demands}
+				{/if}
+			</h3>
+			{$global_demands}
+		</div>
+	{/if}
+
+	{if isset($num_refund_rules) && $num_refund_rules}
+		<div class="panel">
+			<h3>
+				{if $num_refund_rules == 1}
+					{l s='1 refund rule'}
+				{else}
+					{l s='%d refund rules' sprintf=$num_refund_rules}
+				{/if}
+			</h3>
+			{$refund_rules}
+		</div>
 	{/if}
 
 	{if isset($num_customers) && $num_customers}
-	<div class="panel">
-		<h3>
-			{if $num_customers == 1}
-				{l s='1 customer'}
-			{else}
-				{l s='%d customers' sprintf=$num_customers}
-			{/if}
-		</h3>
-		{$customers}
-	</div>
+		<div class="panel">
+			<h3>
+				{if $num_customers == 1}
+					{l s='1 customer'}
+				{else}
+					{l s='%d customers' sprintf=$num_customers}
+				{/if}
+			</h3>
+			{$customers}
+		</div>
+	{/if}
+
+	{if isset($num_groups) && $num_groups}
+		<div class="panel">
+			<h3>
+				{if $num_groups == 1}
+					{l s='1 group'}
+				{else}
+					{l s='%d groups' sprintf=$num_groups}
+				{/if}
+			</h3>
+			{$groups}
+		</div>
+	{/if}
+
+	{if isset($num_customer_address) && $num_customer_address}
+		<div class="panel">
+			<h3>
+				{if $num_customer_address == 1}
+					{l s='1 customer address'}
+				{else}
+					{l s='%d customer addresses' sprintf=$num_customer_address}
+				{/if}
+			</h3>
+			{$customer_address}
+		</div>
+	{/if}
+
+	{if isset($num_order_messages) && $num_order_messages}
+		<div class="panel">
+			<h3>
+				{if $num_order_messages == 1}
+					{l s='1 customer service message'}
+				{else}
+					{l s='%d customer service messages' sprintf=$num_order_messages}
+				{/if}
+			</h3>
+			{$order_messages}
+		</div>
 	{/if}
 
 	{if isset($num_orders) && $num_orders}
-	<div class="panel">
-		<h3>
-			{if $num_orders == 1}
-				{l s='1 order'}
-			{else}
-				{l s='%d orders' sprintf=$num_orders}
-			{/if}
-		</h3>
-		{$orders}
-	</div>
+		<div class="panel">
+			<h3>
+				{if $num_orders == 1}
+					{l s='1 order'}
+				{else}
+					{l s='%d orders' sprintf=$num_orders}
+				{/if}
+			</h3>
+			{$orders}
+		</div>
 	{/if}
 
 	{if isset($addons) && $addons}

--- a/admin/themes/default/template/search_form.tpl
+++ b/admin/themes/default/template/search_form.tpl
@@ -39,41 +39,41 @@
 					</li>
 					<li class="divider"></li>
 					<li class="search-book search-option">
-						<a href="#" data-value="1" data-placeholder="{l s='Product name, SKU, reference...'}" data-icon="icon-book">
+						<a href="#" data-value="{$QLO_SEARCH_TYPE_CATELOG}" data-placeholder="{l s='Room Types, Service products...'}" data-icon="icon-book">
 							<i class="icon-book"></i> {l s='Catalog'}
 						</a>
 					</li>
 					<li class="search-modules search-option">
-						<a href="#" data-value="8" data-placeholder="{l s='Hotel'}" data-icon="icon-AdminHotelReservationSystemManagement">
+						<a href="#" data-value="{$QLO_SEARCH_TYPE_HOTEL}" data-placeholder="{l s='Hotel'}" data-icon="icon-AdminHotelReservationSystemManagement">
 							<i class="icon-building"></i> {l s='Hotel'}
 						</a>
 					</li>
 					<li class="search-customers-name search-option">
-						<a href="#" data-value="2" data-placeholder="{l s='Email, name...'}" data-icon="icon-group">
+						<a href="#" data-value="{$QLO_SEARCH_TYPE_CUSTOMER_BY_NAME}" data-placeholder="{l s='Email, name...'}" data-icon="icon-group">
 							<i class="icon-group"></i> {l s='Customers'} {l s='by name'}
 						</a>
 					</li>
 					<li class="search-customers-addresses search-option">
-						<a href="#" data-value="6" data-placeholder="{l s='123.45.67.89'}" data-icon="icon-desktop">
+						<a href="#" data-value="{$QLO_SEARCH_TYPE_CUSTOMER_BY_IP}" data-placeholder="{l s='123.45.67.89'}" data-icon="icon-desktop">
 							<i class="icon-desktop"></i> {l s='Customers'} {l s='by ip address'}</a>
 					</li>
 					<li class="search-orders search-option">
-						<a href="#" data-value="3" data-placeholder="{l s='Order ID'}" data-icon="icon-credit-card">
+						<a href="#" data-value="{$QLO_SEARCH_TYPE_ORDER}" data-placeholder="{l s='Order ID'}" data-icon="icon-credit-card">
 							<i class="icon-credit-card"></i> {l s='Orders'}
 						</a>
 					</li>
 					<li class="search-invoices search-option">
-						<a href="#" data-value="4" data-placeholder="{l s='Invoice Number'}" data-icon="icon-book">
+						<a href="#" data-value="{$QLO_SEARCH_TYPE_INVOICE}" data-placeholder="{l s='Invoice Number'}" data-icon="icon-book">
 							<i class="icon-book"></i> {l s='Invoices'}
 						</a>
 					</li>
 					<li class="search-carts search-option">
-						<a href="#" data-value="5" data-placeholder="{l s='Cart ID'}" data-icon="icon-shopping-cart">
+						<a href="#" data-value="{$QLO_SEARCH_TYPE_CART}" data-placeholder="{l s='Cart ID'}" data-icon="icon-shopping-cart">
 							<i class="icon-shopping-cart"></i> {l s='Carts'}
 						</a>
 					</li>
 					<li class="search-modules search-option">
-						<a href="#" data-value="7" data-placeholder="{l s='Module name'}" data-icon="icon-puzzle-piece">
+						<a href="#" data-value="{$QLO_SEARCH_TYPE_MODULE}" data-placeholder="{l s='Module name'}" data-icon="icon-puzzle-piece">
 							<i class="icon-puzzle-piece"></i> {l s='Modules'}
 						</a>
 					</li>

--- a/admin/themes/default/template/search_form.tpl
+++ b/admin/themes/default/template/search_form.tpl
@@ -43,6 +43,11 @@
 							<i class="icon-book"></i> {l s='Catalog'}
 						</a>
 					</li>
+					<li class="search-modules search-option">
+						<a href="#" data-value="8" data-placeholder="{l s='Hotel'}" data-icon="icon-AdminHotelReservationSystemManagement">
+							<i class="icon-building"></i> {l s='Hotel'}
+						</a>
+					</li>
 					<li class="search-customers-name search-option">
 						<a href="#" data-value="2" data-placeholder="{l s='Email, name...'}" data-icon="icon-group">
 							<i class="icon-group"></i> {l s='Customers'} {l s='by name'}

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -483,17 +483,29 @@ class AddressCore extends ObjectModel
         return array();
     }
 
-    public function getCustomersAddresses($text)
+    public function searchByName($query, $idLang = false)
     {
+        if (!$idLang) {
+            $idLang = Context::getContext()->language->id;
+        }
+
         return Db::getInstance()->executeS(
-            'SELECT * FROM `'._DB_PREFIX_.'address`
+            'SELECT  a.`id_address`, a.`firstname`, a.`lastname`, a.`address1`, a.`postcode`, a.`city`,
+            cl.`name` AS `country_name`, s.`name` AS `state_name`
+            FROM `'._DB_PREFIX_.'address` a
+            LEFT JOIN `'._DB_PREFIX_.'country_lang` cl
+            ON cl.`id_country` = a.`id_country`
+            LEFT JOIN `'._DB_PREFIX_.'state` s
+            ON s.`id_country` = cl.`id_country`
             WHERE id_customer > 0 AND
-                (address1 LIKE \'%'.$text.'%\' OR
-                    postcode LIKE \'%'.$text.'%\' OR
-                    city LIKE \'%'.$text.'%\' OR
-                    phone LIKE \'%'.$text.'%\' OR
-                    company LIKE \'%'.$text.'%\' OR
-                    alias LIKE \'%'.$text.'%\'
+                (a.`address1` LIKE \'%'.$query.'%\' OR
+                    a.`postcode` LIKE \'%'.$query.'%\' OR
+                    a.`city` LIKE \'%'.$query.'%\' OR
+                    a.`phone` LIKE \'%'.$query.'%\' OR
+                    a.`company` LIKE \'%'.$query.'%\' OR
+                    a.`alias` LIKE \'%'.$query.'%\' OR
+                    s.`name` LIKE \'%'.$query.'%\' OR
+                    cl.`name` LIKE \'%'.$query.'%\'
                 )
         ');
     }

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -482,4 +482,20 @@ class AddressCore extends ObjectModel
         }
         return array();
     }
+
+    public function getCustomersAddresses($text)
+    {
+        return Db::getInstance()->executeS(
+            'SELECT * FROM `'._DB_PREFIX_.'address`
+            WHERE id_customer > 0 AND
+                (address1 LIKE \'%'.$text.'%\' OR
+                    postcode LIKE \'%'.$text.'%\' OR
+                    city LIKE \'%'.$text.'%\' OR
+                    phone LIKE \'%'.$text.'%\' OR
+                    company LIKE \'%'.$text.'%\' OR
+                    alias LIKE \'%'.$text.'%\'
+                )
+        ');
+    }
+
 }

--- a/classes/CustomerMessage.php
+++ b/classes/CustomerMessage.php
@@ -118,7 +118,7 @@ class CustomerMessageCore extends ObjectModel
         }
         return parent::delete();
     }
-    
+
     public static function getMessagesByDate($date)
     {
         return Db::getInstance()->getValue(
@@ -127,4 +127,18 @@ class CustomerMessageCore extends ObjectModel
             WHERE cm.`date_add` BETWEEN "'.pSQL($date).' 00:00:00" AND "'.pSQL($date).' 23:59:59"'
         );
     }
+
+    public function searchCustomerMessage($text)
+    {
+        return Db::getInstance()->executeS(
+            'SELECT cm.*, ct.*, CONCAT(c.firstname, \' \', c.lastname) customer_name
+            FROM `'._DB_PREFIX_.'customer_message` cm
+            LEFT JOIN '._DB_PREFIX_.'customer_thread ct
+            ON (ct.id_customer_thread = cm.id_customer_thread)
+            LEFT JOIN '._DB_PREFIX_.'customer c
+            ON (IFNULL(ct.id_customer, ct.email) = IFNULL(c.id_customer, c.email))
+            WHERE `message` LIKE \'%'.$text.'%\''
+        );
+    }
+
 }

--- a/classes/CustomerMessage.php
+++ b/classes/CustomerMessage.php
@@ -128,17 +128,17 @@ class CustomerMessageCore extends ObjectModel
         );
     }
 
-    public function searchCustomerMessage($text)
+    public function searchByName($query)
     {
-        return Db::getInstance()->executeS(
-            'SELECT cm.*, ct.*, CONCAT(c.firstname, \' \', c.lastname) customer_name
+        return Db::getInstance()->executeS('
+            SELECT cm.*, ct.*, CONCAT(c.`firstname`, \' \', c.`lastname`) `customer_name`
             FROM `'._DB_PREFIX_.'customer_message` cm
             LEFT JOIN '._DB_PREFIX_.'customer_thread ct
-            ON (ct.id_customer_thread = cm.id_customer_thread)
+                ON (ct.`id_customer_thread` = cm.`id_customer_thread`)
             LEFT JOIN '._DB_PREFIX_.'customer c
-            ON (IFNULL(ct.id_customer, ct.email) = IFNULL(c.id_customer, c.email))
-            WHERE `message` LIKE \'%'.$text.'%\''
-        );
+                ON (IFNULL(ct.`id_customer`, ct.`email`) = IFNULL(c.`id_customer`, c.`email`))
+            WHERE `message` LIKE \'%'.$query.'%\'
+        ');
     }
 
 }

--- a/classes/Feature.php
+++ b/classes/Feature.php
@@ -361,4 +361,18 @@ class FeatureCore extends ObjectModel
     {
         return $this->id;
     }
+
+    public static function searchByName($name, $idLang = false)
+    {
+        if (!$idLang) {
+            $idLang = Context::getContext()->language->id;
+        }
+
+        return Db::getInstance()->executeS('
+            SELECT *
+            FROM '._DB_PREFIX_.'feature_lang
+            WHERE `name` LIKE \'%'.pSQL($name).'%\'
+            AND `id_lang`='.(int)$idLang
+        );
+    }
 }

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -373,7 +373,7 @@ class GroupCore extends ObjectModel
 		');
     }
 
-    public function getRelatedGroups($query)
+    public function searchGroupByName($query)
     {
         return Db::getInstance()->executeS('
 			SELECT g.*, gl.*

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -372,4 +372,16 @@ class GroupCore extends ObjectModel
 			WHERE `name` = \''.pSQL($query).'\'
 		');
     }
+
+    public function getRelatedGroups($query)
+    {
+        return Db::getInstance()->executeS('
+			SELECT g.*, gl.*
+			FROM `'._DB_PREFIX_.'group` g
+			LEFT JOIN `'._DB_PREFIX_.'group_lang` gl
+				ON (g.`id_group` = gl.`id_group`)
+			WHERE `name` LIKE \'%'.pSQL($query).'%\'
+		');
+    }
+
 }

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -373,7 +373,7 @@ class GroupCore extends ObjectModel
 		');
     }
 
-    public function searchGroupByName($query)
+    public function searchGroupsByName($query)
     {
         return Db::getInstance()->executeS('
 			SELECT g.*, gl.*

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -397,6 +397,14 @@ class AdminControllerCore extends Controller
 
     /** @var int level for permissions View/read */
     const LEVEL_VIEW = 1;
+    const QLO_SEARCH_TYPE_CATELOG = 1;
+    const QLO_SEARCH_TYPE_CUSTOMER_BY_NAME = 2;
+    const QLO_SEARCH_TYPE_ORDER = 3;
+    const QLO_SEARCH_TYPE_INVOICE = 4;
+    const QLO_SEARCH_TYPE_CART = 5;
+    const QLO_SEARCH_TYPE_CUSTOMER_BY_IP = 6;
+    const QLO_SEARCH_TYPE_MODULE = 7;
+    const QLO_SEARCH_TYPE_HOTEL = 8;
 
     public function __construct()
     {
@@ -2030,6 +2038,14 @@ class AdminControllerCore extends Controller
                 'employee' => $this->context->employee,
                 'search_type' => Tools::getValue('bo_search_type'),
                 'bo_query' => Tools::safeOutput(Tools::stripslashes(Tools::getValue('bo_query'))),
+                'QLO_SEARCH_TYPE_CATELOG' => self::QLO_SEARCH_TYPE_CATELOG,
+                'QLO_SEARCH_TYPE_CUSTOMER_BY_NAME' => self::QLO_SEARCH_TYPE_CUSTOMER_BY_NAME,
+                'QLO_SEARCH_TYPE_CUSTOMER_BY_IP' => self::QLO_SEARCH_TYPE_CUSTOMER_BY_IP,
+                'QLO_SEARCH_TYPE_ORDER' => self::QLO_SEARCH_TYPE_ORDER,
+                'QLO_SEARCH_TYPE_INVOICE' => self::QLO_SEARCH_TYPE_INVOICE,
+                'QLO_SEARCH_TYPE_CART' => self::QLO_SEARCH_TYPE_CART,
+                'QLO_SEARCH_TYPE_MODULE' => self::QLO_SEARCH_TYPE_MODULE,
+                'QLO_SEARCH_TYPE_HOTEL' => self::QLO_SEARCH_TYPE_HOTEL,
                 'quick_access' => $quick_access,
                 'multi_shop' => Shop::isFeatureActive(),
                 'shop_list' => $helperShop->getRenderedShopList(),

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -298,7 +298,7 @@ class AdminSearchControllerCore extends AdminController
 
         $objGroup = new Group();
         if (isset($this->controllerAccess['AdminGroups']) && $this->controllerAccess['AdminGroups']) {
-            $this->_list['groups'] = $objGroup->searchGroupByName($this->query);
+            $this->_list['groups'] = $objGroup->searchGroupsByName($this->query);
         }
     }
 

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -30,6 +30,22 @@ class AdminSearchControllerCore extends AdminController
     {
         $this->bootstrap = true;
         parent::__construct();
+        $this->controllers = array(
+            'AdminProducts' => 1,
+            'AdminCategories' => 1,
+            'AdminFeatures' => 1,
+            'AdminOrders' => 1,
+            'AdminOrderRefundRules' => 1,
+            'AdminRoomTypeGlobalDemand' => 1,
+            'AdminGroups' => 1,
+            'AdminHotelFeatures' => 1,
+            'AdminCustomers' => 1,
+            'AdminAddHotel' => 1,
+            'AdminNormalProducts' => 1,
+            'AdminAddresses' => 1,
+            'AdminCustomerThreads' => 1,
+            'AdminModules' => 1
+        );
     }
 
     public function postProcess()
@@ -39,6 +55,10 @@ class AdminSearchControllerCore extends AdminController
         $searchType = (int)Tools::getValue('bo_search_type');
         /* Handle empty search field */
         if (!empty($this->query)) {
+            if ($this->context->employee->id_profile != _PS_ADMIN_PROFILE_) {
+                $this->setControllerAccesses();
+            }
+
             if (!$searchType && strlen($this->query) > 1) {
                 $this->searchFeatures();
             }
@@ -48,7 +68,11 @@ class AdminSearchControllerCore extends AdminController
                 /* Handle product ID */
                 if ($searchType == 1 && (int)$this->query && Validate::isUnsignedInt((int)$this->query)) {
                     if (($product = new Product($this->query)) && Validate::isLoadedObject($product)) {
-                        Tools::redirectAdmin('index.php?tab=AdminProducts&id_product='.(int)($product->id).'&token='.Tools::getAdminTokenLite('AdminProducts'));
+                        if ($product->booking_product) {
+                            Tools::redirectAdmin('index.php?tab=AdminProducts&id_product='.(int)($product->id).'&updateproduct&token='.Tools::getAdminTokenLite('AdminProducts'));
+                        } else {
+                            Tools::redirectAdmin('index.php?tab=AdminNormalProducts&id_product='.(int)($product->id).'&updateproduct&token='.Tools::getAdminTokenLite('AdminNormalProducts'));
+                        }
                     }
                 }
 
@@ -72,6 +96,10 @@ class AdminSearchControllerCore extends AdminController
 
                 if ($searchType == 6) {
                     $this->searchIP();
+                }
+
+                if (isset($this->_list['customers']) && is_array($this->_list['customers']) && count($this->_list['customers'])) {
+                    $this->addHotelRestrictionsToSearchedCustomers('customers');
                 }
             }
 
@@ -113,10 +141,10 @@ class AdminSearchControllerCore extends AdminController
                                 $this->_list['orders'][] = $row;
                             }
                         }
-                    } elseif ($searchType == 3) {
-                        $this->errors[] = Tools::displayError('No order was found with this ID:').' '.Tools::htmlentitiesUTF8($this->query);
                     }
                 }
+
+                $this->searchOrderMessages();
             }
 
             /* Invoices */
@@ -147,10 +175,44 @@ class AdminSearchControllerCore extends AdminController
                 /* Normal catalog search */
                 $this->searchModule();
             }
+
+            if (!$searchType || $searchType == 8) {
+                if ($searchType == 8 && (int)$this->query && Validate::isUnsignedInt((int)$this->query)) {
+                    if (($objHotelBranchInfo = new HotelBranchInformation((int) $this->query))
+                        && Validate::isLoadedObject($objHotelBranchInfo)
+                    ) {
+                        Tools::redirectAdmin('index.php?tab=AdminAddHotel&id='.$objHotelBranchInfo->id.'&updatehtl_branch_info'.'&token='.Tools::getAdminTokenLite('AdminAddHotel'));
+                    }
+                }
+
+                $this->searchHotel();
+            }
+
+            if (!$searchType) {
+                $this->searchAddress();
+                $this->searchHotelFeatures();
+                $this->searchAdditionalFacilities();
+                $this->searchRefundRules();
+            }
         }
+
         $this->display = 'view';
     }
 
+    public function setControllerAccesses()
+    {
+        $sql = 'SELECT a.`view`, t.`class_name` FROM `'._DB_PREFIX_.'access` a
+            LEFT JOIN `'._DB_PREFIX_.'tab` t ON (t.`id_tab` = a.`id_tab`)
+            WHERE t.`class_name` IN ("'.implode('", "', array_keys($this->controllers)).'")
+            AND a.`id_profile` = '.(int) $this->context->employee->id_profile.'
+        ';
+
+        if ($tabs = Db::getInstance()->executeS($sql)) {
+            foreach ($tabs as $tab) {
+                $this->controllers[$tab['class_name']] = $tab['view'];
+            }
+        }
+    }
 
     public function searchIP()
     {
@@ -168,44 +230,43 @@ class AdminSearchControllerCore extends AdminController
     */
     public function searchCatalog()
     {
-        $this->context = Context::getContext();
-        if ($this->_list['products'] = Product::searchByName($this->context->language->id, $this->query)) {
+        if (isset($this->controllers['AdminProducts'])
+            && $this->controllers['AdminProducts']
+            && ($this->_list['products'] = Product::searchByName($this->context->language->id, $this->query))
+        ) {
             $objRoomType = new HotelRoomType();
+            $accessableHotels = HotelBranchInformation::getProfileAccessedHotels($this->context->employee->id_profile, 1, 1);
             $objRoomTypeServiceProduct = new RoomTypeServiceProduct();
-            $accessibleHotels = HotelBranchInformation::getProfileAccessedHotels(
-                $this->context->employee->id_profile,
-                1,
-                1
-            );
-
             foreach ($this->_list['products'] as $key => $product) {
-                $toUnset = false;
-                if ($product['booking_product']) {
-                    $roomInfo = $objRoomType->getRoomTypeInfoByIdProduct($product['id_product']);
-                    if (!in_array($roomInfo['id_hotel'], $accessibleHotels)) {
-                        $toUnset = true;
+                if ($roomInfo = $objRoomType->getRoomTypeInfoByIdProduct($product['id_product'])) {
+                    if (!in_array($roomInfo['id_hotel'], $accessableHotels)) {
+                        unset($this->_list['products'][$key]);
                     }
-                } else {
-                    $associations = $objRoomTypeServiceProduct->getAssociatedHotelsAndRoomType($product['id_product']);
-                    // proceed only if access can not be determined from hotels
-                    if (!count(array_intersect($associations['hotels'], $accessibleHotels))) {
-                        $toUnset = true;
-                        foreach ($associations['room_types'] as $idProduct) {
-                            $roomTypeInfo = $objRoomType->getRoomTypeInfoByIdProduct($idProduct);
-                            if (in_array($roomTypeInfo['id_hotel'], $accessibleHotels)) {
-                                $toUnset = false;
-                                break;
-                            }
+                } else if ($associatedData = $objRoomTypeServiceProduct->getAssociatedHotelsAndRoomType($product['id_product'])) {
+                    $count = 0;
+                    foreach ($associatedData['room_types'] as $id_room_type) {
+                        $objRoomType = new HotelRoomType($id_room_type);
+                        if (in_array($objRoomType->id_hotel, $accessableHotels)) {
+                            $count += 1;
                         }
                     }
-                }
 
-                if ($toUnset) {
+                    if ($count) {
+                        $this->_list['service_products'][] = $this->_list['products'][$key];
+                    }
+
                     unset($this->_list['products'][$key]);
                 }
             }
         }
-        $this->_list['categories'] = Category::searchByName($this->context->language->id, $this->query);
+
+        if (isset($this->controllers['AdminCategories']) && $this->controllers['AdminCategories']) {
+            $this->_list['categories'] = Category::searchByName($this->context->language->id, $this->query);
+        }
+
+        if (isset($this->controllers['AdminFeatures']) && $this->controllers['AdminFeatures']) {
+            $this->_list['catalog_features'] = Feature::searchByName($this->query, $this->context->language->id);
+        }
     }
 
     /**
@@ -215,29 +276,41 @@ class AdminSearchControllerCore extends AdminController
     */
     public function searchCustomer()
     {
-        $this->_list['customers'] = Customer::searchByName($this->query);
+
+        if (isset($this->controllers['AdminCustomers'])
+            && $this->controllers['AdminCustomers']
+        ) {
+            $this->_list['customers'] = Customer::searchByName($this->query);
+        }
+
+        $objGroup = new Group();
+        if (isset($this->controllers['AdminGroups']) && $this->controllers['AdminGroups']) {
+            $this->_list['groups'] = $objGroup->getRelatedGroups($this->query);
+        }
     }
 
     public function searchModule()
     {
-        $this->_list['modules'] = array();
-        $all_modules = Module::getModulesOnDisk(true, true, Context::getContext()->employee->id);
-        foreach ($all_modules as $module) {
-            if (stripos($module->name, $this->query) !== false || stripos($module->displayName, $this->query) !== false || stripos($module->description, $this->query) !== false) {
-                $module->linkto = 'index.php?tab=AdminModules&tab_module='.$module->tab.'&module_name='.$module->name.'&anchor='.ucfirst($module->name).'&token='.Tools::getAdminTokenLite('AdminModules');
-                $this->_list['modules'][] = $module;
+        if (isset($this->controllers['AdminModules']) && $this->controllers['AdminModules']) {
+            $this->_list['modules'] = array();
+            $all_modules = Module::getModulesOnDisk(true, true, Context::getContext()->employee->id);
+            foreach ($all_modules as $module) {
+                if (stripos($module->name, $this->query) !== false || stripos($module->displayName, $this->query) !== false || stripos($module->description, $this->query) !== false) {
+                    $module->linkto = 'index.php?tab=AdminModules&tab_module='.$module->tab.'&module_name='.$module->name.'&anchor='.ucfirst($module->name).'&token='.Tools::getAdminTokenLite('AdminModules');
+                    $this->_list['modules'][] = $module;
+                }
             }
-        }
 
-        if (!is_numeric(trim($this->query)) && !Validate::isEmail($this->query)) {
-            $iso_lang = Tools::strtolower(Context::getContext()->language->iso_code);
-            $iso_country = Tools::strtolower(Country::getIsoById(Configuration::get('PS_COUNTRY_DEFAULT')));
-            if (($json_content = Tools::file_get_contents('https://api-addons.prestashop.com/'._PS_VERSION_.'/search/'.urlencode($this->query).'/'.$iso_country.'/'.$iso_lang.'/')) != false) {
-                $results = json_decode($json_content, true);
-                if (isset($results['id'])) {
-                    $this->_list['addons']  = array($results);
-                } else {
-                    $this->_list['addons']  =  $results;
+            if (!is_numeric(trim($this->query)) && !Validate::isEmail($this->query)) {
+                $iso_lang = Tools::strtolower(Context::getContext()->language->iso_code);
+                $iso_country = Tools::strtolower(Country::getIsoById(Configuration::get('PS_COUNTRY_DEFAULT')));
+                if (($json_content = Tools::file_get_contents('https://api-addons.prestashop.com/'._PS_VERSION_.'/search/'.urlencode($this->query).'/'.$iso_country.'/'.$iso_lang.'/')) != false) {
+                    $results = json_decode($json_content, true);
+                    if (isset($results['id'])) {
+                        $this->_list['addons']  = array($results);
+                    } else {
+                        $this->_list['addons']  =  $results;
+                    }
                 }
             }
         }
@@ -301,8 +374,167 @@ class AdminSearchControllerCore extends AdminController
         }
     }
 
+    public function searchHotel()
+    {
+        if (class_exists('HotelBranchInformation')) {
+            if (isset($this->controllers['AdminAddHotel']) && $this->controllers['AdminAddHotel']) {
+                $objHotelBranchInformation = new HotelBranchInformation();
+                $this->_list['hotels'] = $objHotelBranchInformation->getAccessibleHotelByName($this->query);
+            }
+        }
+    }
+
+    public function searchOrderMessages()
+    {
+        if (class_exists('CustomerMessage')) {
+            if (isset($this->controllers['AdminCustomerThreads']) && $this->controllers['AdminCustomerThreads']) {
+                $objCustomerMessage = new CustomerMessage();
+                if ($this->_list['order_messages'] = $objCustomerMessage->searchCustomerMessage($this->query)) {
+                    $accesibleHotels = HotelBranchInformation::getProfileAccessedHotels($this->context->employee->id_profile, 1, 1);
+                    foreach ($this->_list['order_messages'] as $key => $msg) {
+                        if ($msg['id_order']) {
+                            // To set set restriction on the messages belonging to an order. While the other messages will be show to all
+                            $idHotel = HotelBookingDetail::getIdHotelByIdOrder($msg['id_order']);
+                            if (!in_array($idHotel, $accesibleHotels)) {
+                                unset($this->_list['order_messages'][$key]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public function searchAddress()
+    {
+        if (isset($this->controllers['AdminAddresses']) && $this->controllers['AdminAddresses']) {
+            $objAddress = new Address();
+            if ($this->_list['customer_address'] = $objAddress->getCustomersAddresses($this->query)) {
+                $this->addHotelRestrictionsToSearchedCustomers('customer_address');
+            }
+        }
+    }
+
+    public function searchHotelFeatures()
+    {
+        if (class_exists('HotelFeatures')) {
+            if (isset($this->controllers['AdminHotelFeatures']) && $this->controllers['AdminHotelFeatures']) {
+                $objHotelFeatures = new HotelFeatures();
+                if ($hotelFeatures = $objHotelFeatures->searchHotelFeatureByName($this->query)) {
+                    $features = array();
+                    foreach ($hotelFeatures as $key => $hotelFeature) {
+                        $features[$hotelFeature['id']]['name'] = $hotelFeature['name'];
+                        if ($hotelFeature['parent_feature_id']) {
+                            $features[$hotelFeature['id']]['id'] = $hotelFeature['parent_feature_id'];
+                        } else {
+                            $features[$hotelFeature['id']]['id'] = $hotelFeature['id'];
+                        }
+                    }
+
+                    $this->_list['hotel_features'] = $features;
+                }
+            }
+        }
+    }
+
+    public function searchAdditionalFacilities()
+    {
+        if (class_exists('HotelRoomTypeGlobalDemand')) {
+            if (isset($this->controllers['AdminRoomTypeGlobalDemand']) && $this->controllers['AdminRoomTypeGlobalDemand']) {
+                $objHotelRoomTypeGlobalDemands = new HotelRoomTypeGlobalDemand();
+                if ($globalDemads = $objHotelRoomTypeGlobalDemands->searchRoomTypeDemandsByName($this->query)) {
+                    foreach ($globalDemads as $key => $demand) {
+                        if (!(int) $globalDemads[$key]['price']) {
+                            $globalDemads[$key]['price'] = $globalDemads[$key]['option_price'];
+                        }
+
+                        $globalDemads[$key]['per_day_price_calc'] = $this->l('No');
+                        if ($globalDemads[$key]['price_calc_method'] == HotelRoomTypeGlobalDemand::WK_PRICE_CALC_METHOD_EACH_DAY) {
+                            $globalDemads[$key]['per_day_price_calc'] = $this->l('Yes');
+                        }
+                    }
+
+                    $this->_list['global_demands'] = $globalDemads;
+                }
+            }
+        }
+    }
+
+    public function searchRefundRules()
+    {
+        if (class_exists('HotelOrderRefundRules')) {
+            if (isset($this->controllers['AdminOrderRefundRulesController']) && $this->controllers['AdminOrderRefundRulesController']) {
+                $objRefundRule = new HotelOrderRefundRules();
+                if ($refundRules = $objRefundRule->searchOrderRefundRulesByName($this->query)) {
+                    foreach ($refundRules as $key => $rule) {
+                        $refundRules[$key]['deduction_type'] = $this->l('Percentage');
+                        if ($rule['payment_type'] == HotelOrderRefundRules::WK_REFUND_RULE_PAYMENT_TYPE_FIXED) {
+                            $refundRules[$key]['deduction_type'] = $this->l('Fixed Amount');
+                            $refundRules[$key]['deduction_value_full_pay'] = Tools::displayPrice($rule['deduction_value_full_pay']);
+                            $refundRules[$key]['deduction_value_adv_pay'] = Tools::displayPrice($rule['deduction_value_adv_pay']);
+                        } else if ($rule['payment_type'] == HotelOrderRefundRules::WK_REFUND_RULE_PAYMENT_TYPE_PERCENTAGE) {
+                            $refundRules[$key]['deduction_value_full_pay'] = $rule['deduction_value_full_pay'].' %';
+                            $refundRules[$key]['deduction_value_adv_pay'] = $rule['deduction_value_adv_pay'].' %';
+                        }
+                    }
+
+                    $this->_list['refund_rules'] = $refundRules;
+                }
+            }
+        }
+    }
+
+    protected function addHotelRestrictionsToSearchedCustomers($index)
+    {
+        $accessibleHotels = HotelBranchInformation::getProfileAccessedHotels($this->context->employee->id_profile, 1, 1);
+        foreach ($this->_list[$index] as $key => $item) {
+            if ($this->context->employee->id_profile != _PS_ADMIN_PROFILE_) {
+                $customerBelongsToHotel = 0;
+                if(isset($item['id_customer'])) {
+                    $customerOrders = Order::getCustomerOrders($item['id_customer']);
+                    if (count($customerOrders)) {
+                        foreach($customerOrders as $order) {
+                            $idHotel = HotelBookingDetail::getIdHotelByIdOrder($order['id_order']);
+                            if (!in_array($idHotel, $accessibleHotels)) {
+                                $customerBelongsToHotel += 1;
+                            }
+                        }
+                    }
+                }
+
+                if (!$customerBelongsToHotel) {
+                    unset($this->_list[$index][$key]);
+                }
+            }
+        }
+    }
+
+    protected function initGroupList()
+    {
+        $this->show_toolbar = false;
+        $this->fields_list['groups'] = array(
+            'id_group' => array('title' => $this->l('ID'), 'align' => 'center', 'width' => 25),
+            'name' => array('title' => $this->l('Name'), 'align' => 'center', 'width' => 65),
+            'reduction' => array('title' => $this->l('Discount')),
+            'show_prices' => array('title' => $this->l('Show prices'), 'callback' => 'printShowPricesIcon'),
+            'date_add' => array('title' => $this->l('Creation date'), 'width' => 130, 'align' => 'right', 'type' => 'datetime'),
+        );
+    }
+
+    public function printShowPricesIcon($id_group, $tr)
+    {
+        $group = new Group($tr['id_group']);
+        if (!Validate::isLoadedObject($group)) {
+            return;
+        }
+        return '<a class="list-action-enable'.($group->show_prices ? ' action-enabled' : ' action-disabled').'" href="index.php?tab=AdminGroups&amp;id_group='.(int)$group->id.'&amp;changeShowPricesVal&amp;token='.Tools::getAdminTokenLite('AdminGroups').'">
+				'.($group->show_prices ? '<i class="icon-check"></i>' : '<i class="icon-remove"></i>').
+            '</a>';
+    }
+
     protected function initOrderList()
     {
+        $this->show_toolbar = false;
         $this->fields_list['orders'] = array(
             'reference' => array('title' => $this->l('Reference'), 'align' => 'center', 'width' => 65),
             'id_order' => array('title' => $this->l('ID'), 'align' => 'center', 'width' => 25),
@@ -311,6 +543,43 @@ class AdminSearchControllerCore extends AdminController
             'payment' => array( 'title' => $this->l('Payment'), 'width' => 100),
             'osname' => array('title' => $this->l('Status'), 'width' => 280),
             'date_add' => array('title' => $this->l('Date'), 'width' => 130, 'align' => 'right', 'type' => 'datetime'),
+        );
+    }
+
+    protected function initGlobalDemandList()
+    {
+        $this->show_toolbar = false;
+        $this->fields_list['global_demands'] = array(
+            'id_global_demand' => array('title' => $this->l('ID'), 'align' => 'center', 'width' => 25),
+            'name' => array('title' => $this->l('Name')),
+            'option_name' => array('title' => $this->l('Advance Option Name')),
+            'price' => array('title' => $this->l('Price'), 'type' => 'price', 'currency' => true),
+            'per_day_price_calc' => array('title' => $this->l('Per day price calculation'))
+        );
+    }
+
+    protected function initRefundRuleList()
+    {
+        $this->show_toolbar = false;
+        $this->fields_list['refund_rules'] = array(
+            'id_refund_rule' => array('title' => $this->l('ID'), 'align' => 'center', 'width' => 25),
+            'name' => array('title' => $this->l('Name')),
+            'payment_type' => array('title' => $this->l('Payment Type')),
+            'deduction_value_full_pay' => array('title' => $this->l('Full Payment Deduction Percentage/Amount')),
+            'deduction_value_adv_pay' => array('title' => $this->l('Full Payment Deduction Percentage/Amount')),
+            'days' => array('title' => $this->l('Days Before Check-in')),
+        );
+    }
+
+    protected function initOrderMessagesList()
+    {
+        $this->show_toolbar = false;
+        $this->fields_list['order_messages'] = array(
+            'id_customer_thread' => array('title' => $this->l('ID '), 'align' => 'center', 'width' => 65),
+            'customer_name' => array('title' => $this->l('Customer Name'), 'align' => 'center'),
+            'email' => array('title' => $this->l('Customer email')),
+            'message' => array('title' => $this->l('Message'), 'width' => 70),
+            'status' => array('title' => $this->l('Status'), 'width' => 280),
         );
     }
 
@@ -342,10 +611,66 @@ class AdminSearchControllerCore extends AdminController
         $this->fields_list['products'] = array(
             'id_product' => array('title' => $this->l('ID'), 'width' => 25),
             'name' => array('title' => $this->l('Name'), 'width' => 'auto'),
-            'reference' => array('title' => $this->l('Reference'), 'align' => 'center', 'width' => 150),
+            // 'reference' => array('title' => $this->l('Reference'), 'align' => 'center', 'width' => 150),
             'price_tax_excl' => array('title' => $this->l('Price (tax excl.)'), 'align' => 'right', 'type' => 'price', 'width' => 60),
             'price_tax_incl' => array('title' => $this->l('Price (tax incl.)'), 'align' => 'right', 'type' => 'price', 'width' => 60),
             'active' => array('title' => $this->l('Active'), 'width' => 70, 'active' => 'status', 'align' => 'center', 'type' => 'bool')
+        );
+    }
+
+    protected function initServiceProdList()
+    {
+        $this->show_toolbar = false;
+        $this->fields_list['service_products'] = array(
+            'id_product' => array('title' => $this->l('ID'), 'width' => 25),
+            'name' => array('title' => $this->l('Name'), 'width' => 'auto'),
+            'price_tax_excl' => array('title' => $this->l('Price (tax excl.)'), 'align' => 'right', 'type' => 'price', 'width' => 60),
+            'price_tax_incl' => array('title' => $this->l('Price (tax incl.)'), 'align' => 'right', 'type' => 'price', 'width' => 60),
+            'active' => array('title' => $this->l('Active'), 'width' => 70, 'active' => 'status', 'align' => 'center', 'type' => 'bool')
+        );
+    }
+
+    protected function initFeatureList()
+    {
+        $this->show_toolbar = false;
+        $this->fields_list['catalog_features'] = array(
+            'id_feature' => array('title' => $this->l('ID'), 'width' => 25),
+            'name' => array('title' => $this->l('Name'), 'width' => 'auto'),
+            'logo' => array('title' => $this->l('Logo'),'image' => 'rf', 'align' => 'right', 'type' => 'price', 'width' => 60),
+        );
+    }
+
+    protected function initHotelList()
+    {
+        $this->show_toolbar = false;
+        $this->fields_list['hotels'] = array(
+            'id' => array('title' => $this->l('ID'), 'width' => 25),
+            'hotel_name' => array('title' => $this->l('Name'), 'width' => 'auto'),
+            'city' => array('title' => $this->l('City'), 'align' => 'right'),
+            'state_name' => array('title' => $this->l('State'), 'align' => 'right'),
+            'country_name' => array('title' => $this->l('Country'), 'align' => 'right'),
+            'active' => array('title' => $this->l('Active'), 'width' => 70, 'active' => 'status', 'align' => 'center', 'type' => 'bool')
+        );
+    }
+
+    protected function initAddressList()
+    {
+        $this->show_toolbar = false;
+        $this->fields_list['customer_address'] = array(
+            'id_address' => array('title' => $this->l('ID'), 'width' => 25),
+            'firstname' => array('title' => $this->l('First Name'), 'width' => 'auto'),
+            'lastname' => array('title' => $this->l('Last Name'), 'align' => 'right'),
+            'address1' => array('title' => $this->l('Address'), 'align' => 'right'),
+            'postcode' => array('title' => $this->l('Zip/Postal Code'), 'align' => 'right'),
+            'city' => array('title' => $this->l('City'), 'width' => 70)
+        );
+    }
+
+    protected function initHotelFeatureList()
+    {
+        $this->show_toolbar = false;
+        $this->fields_list['hotel_features'] = array(
+            'name' => array('title' => $this->l('name'), 'width' => 'auto'),
         );
     }
 
@@ -403,7 +728,6 @@ class AdminSearchControllerCore extends AdminController
                 $helper->show_toolbar = false;
                 $helper->table = 'product';
                 $helper->currentIndex = $this->context->link->getAdminLink('AdminProducts', false);
-
                 $query = trim(Tools::getValue('bo_query'));
                 $searchType = (int)Tools::getValue('bo_search_type');
 
@@ -419,6 +743,152 @@ class AdminSearchControllerCore extends AdminController
 
                 $this->tpl_view_vars['num_products'] = count($this->_list['products']);
                 $this->tpl_view_vars['products'] = $view;
+            }
+            if (isset($this->_list['service_products']) && $this->_list['service_products']&& count($this->_list['service_products'])) {
+                $view = '';
+                $this->initServiceProdList();
+
+                $helper = new HelperList();
+                $helper->shopLinkType = '';
+                $helper->simple_header = true;
+                $helper->identifier = 'id_product';
+                $helper->actions = array('edit');
+                $helper->show_toolbar = false;
+                $helper->table = 'product';
+                $helper->currentIndex = $this->context->link->getAdminLink('AdminNormalProducts', false);
+
+                $query = trim(Tools::getValue('bo_query'));
+                $searchType = (int)Tools::getValue('bo_search_type');
+
+                if ($query) {
+                    $helper->currentIndex .= '&bo_query='.$query.'&bo_search_type='.$searchType;
+                }
+
+                $helper->token = Tools::getAdminTokenLite('AdminNormalProducts');
+
+                if ($this->_list['service_products']) {
+                    $view = $helper->generateList($this->_list['service_products'], $this->fields_list['service_products']);
+                }
+
+                $this->tpl_view_vars['num_service_products'] = count($this->_list['service_products']);
+                $this->tpl_view_vars['service_products'] = $view;
+            }
+            if (isset($this->_list['catalog_features']) && $this->_list['catalog_features']&& count($this->_list['catalog_features'])) {
+                $view = '';
+                $this->initFeatureList();
+
+                $helper = new HelperList();
+                $helper->shopLinkType = '';
+                $helper->simple_header = true;
+                $helper->identifier = 'id_feature';
+                $helper->imageType = 'jpg';
+                $helper->actions = array('edit');
+                $helper->show_toolbar = false;
+                $helper->table = 'feature';
+                $helper->currentIndex = $this->context->link->getAdminLink('AdminFeatures', false);
+
+                $query = trim(Tools::getValue('bo_query'));
+                $searchType = (int)Tools::getValue('bo_search_type');
+
+                if ($query) {
+                    $helper->currentIndex .= '&bo_query='.$query.'&bo_search_type='.$searchType;
+                }
+
+                $helper->token = Tools::getAdminTokenLite('AdminFeatures');
+
+                if ($this->_list['catalog_features']) {
+                    $view = $helper->generateList($this->_list['catalog_features'], $this->fields_list['catalog_features']);
+                }
+
+                $this->tpl_view_vars['num_catalog_features'] = count($this->_list['catalog_features']);
+                $this->tpl_view_vars['catalog_features'] = $view;
+            }
+            if (isset($this->_list['customer_address']) && $this->_list['customer_address']&& count($this->_list['customer_address'])) {
+                $view = '';
+                $this->initAddressList();
+
+                $helper = new HelperList();
+                $helper->shopLinkType = '';
+                $helper->simple_header = true;
+                $helper->identifier = 'id_address';
+                $helper->actions = array('edit');
+                $helper->show_toolbar = false;
+                $helper->table = 'address';
+                $helper->currentIndex = $this->context->link->getAdminLink('AdminAddresses', false);
+
+                $query = trim(Tools::getValue('bo_query'));
+                $searchType = (int)Tools::getValue('bo_search_type');
+
+                if ($query) {
+                    $helper->currentIndex .= '&bo_query='.$query.'&bo_search_type='.$searchType;
+                }
+
+                $helper->token = Tools::getAdminTokenLite('AdminAddresses');
+
+                if ($this->_list['customer_address']) {
+                    $view = $helper->generateList($this->_list['customer_address'], $this->fields_list['customer_address']);
+                }
+
+                $this->tpl_view_vars['num_customer_address'] = count($this->_list['customer_address']);
+                $this->tpl_view_vars['customer_address'] = $view;
+            }
+            if (isset($this->_list['order_messages']) && $this->_list['order_messages']&& count($this->_list['order_messages'])) {
+                $view = '';
+                $this->initOrderMessagesList();
+
+                $helper = new HelperList();
+                $helper->shopLinkType = '';
+                $helper->simple_header = true;
+                $helper->identifier = 'id_customer_message';
+                $helper->actions = array('edit');
+                $helper->show_toolbar = false;
+                $helper->table = 'feature';
+                $helper->currentIndex = $this->context->link->getAdminLink('AdminCustomerThreads', false);
+
+                $query = trim(Tools::getValue('bo_query'));
+                $searchType = (int)Tools::getValue('bo_search_type');
+
+                if ($query) {
+                    $helper->currentIndex .= '&bo_query='.$query.'&bo_search_type='.$searchType;
+                }
+
+                $helper->token = Tools::getAdminTokenLite('AdminCustomerThreads');
+
+                if ($this->_list['order_messages']) {
+                    $view = $helper->generateList($this->_list['order_messages'], $this->fields_list['order_messages']);
+                }
+
+                $this->tpl_view_vars['num_order_messages'] = count($this->_list['order_messages']);
+                $this->tpl_view_vars['order_messages'] = $view;
+            }
+            if (isset($this->_list['hotels']) && $this->_list['hotels']&& count($this->_list['hotels'])) {
+                $view = '';
+                $this->initHotelList();
+
+                $helper = new HelperList();
+                $helper->shopLinkType = '';
+                $helper->simple_header = true;
+                $helper->identifier = 'id';
+                $helper->actions = array('edit');
+                $helper->show_toolbar = false;
+                $helper->table = 'htl_branch_info';
+                $helper->currentIndex = $this->context->link->getAdminLink('AdminAddHotel', false);
+
+                $query = trim(Tools::getValue('bo_query'));
+                $searchType = (int)Tools::getValue('bo_search_type');
+
+                if ($query) {
+                    $helper->currentIndex .= '&bo_query='.$query.'&bo_search_type='.$searchType;
+                }
+
+                $helper->token = Tools::getAdminTokenLite('AdminAddHotel');
+
+                if ($this->_list['hotels']) {
+                    $view = $helper->generateList($this->_list['hotels'], $this->fields_list['hotels']);
+                }
+
+                $this->tpl_view_vars['num_hotels'] = count($this->_list['hotels']);
+                $this->tpl_view_vars['hotels'] = $view;
             }
             if (isset($this->_list['customers']) && count($this->_list['customers'])) {
                 $view = '';
@@ -443,6 +913,101 @@ class AdminSearchControllerCore extends AdminController
                 $this->tpl_view_vars['num_customers'] = count($this->_list['customers']);
                 $this->tpl_view_vars['customers'] = $view;
             }
+
+            if (isset($this->_list['hotel_features']) && count($this->_list['hotel_features'])) {
+                $view = '';
+                $this->initHotelFeatureList();
+
+                $helper = new HelperList();
+                $helper->shopLinkType = '';
+                $helper->simple_header = true;
+                $helper->identifier = 'id';
+                $helper->actions = array('edit', 'view');
+                $helper->show_toolbar = false;
+                $helper->table = 'htl_features';
+                $helper->currentIndex = $this->context->link->getAdminLink('AdminHotelFeatures', false);
+                $helper->token = Tools::getAdminTokenLite('AdminHotelFeatures');
+
+                if ($this->_list['hotel_features']) {
+                    $view = $helper->generateList($this->_list['hotel_features'], $this->fields_list['hotel_features']);
+                }
+
+                $this->tpl_view_vars['num_hotel_features'] = count($this->_list['hotel_features']);
+                $this->tpl_view_vars['hotel_features'] = $view;
+            }
+            if (isset($this->_list['groups']) && count($this->_list['groups'])) {
+                $view = '';
+                $this->initGroupList();
+
+                $helper = new HelperList();
+                $helper->shopLinkType = '';
+                $helper->simple_header = true;
+                $helper->identifier = 'id_group';
+                $helper->actions = array('edit');
+                $helper->show_toolbar = false;
+                $helper->table = 'group';
+                $helper->currentIndex = $this->context->link->getAdminLink('AdminGroups', false);
+
+                $query = trim(Tools::getValue('bo_query'));
+                $searchType = (int)Tools::getValue('bo_search_type');
+
+                if ($query) {
+                    $helper->currentIndex .= '&bo_query='.$query.'&bo_search_type='.$searchType;
+                }
+
+                $helper->token = Tools::getAdminTokenLite('AdminGroups');
+
+                if ($this->_list['groups']) {
+                    $view = $helper->generateList($this->_list['groups'], $this->fields_list['groups']);
+                }
+
+                $this->tpl_view_vars['num_groups'] = count($this->_list['groups']);
+                $this->tpl_view_vars['groups'] = $view;
+            }
+
+            if (isset($this->_list['global_demands']) && count($this->_list['global_demands'])) {
+                $view = '';
+                $this->initGlobalDemandList();
+                $helper = new HelperList();
+                $helper->shopLinkType = '';
+                $helper->simple_header = true;
+                $helper->identifier = 'id_global_demand';
+                $helper->actions = array('edit');
+                $helper->show_toolbar = false;
+                $helper->table = 'htl_room_type_global_demand';
+                $helper->currentIndex = $this->context->link->getAdminLink('AdminRoomTypeGlobalDemand', false);
+                $helper->token = Tools::getAdminTokenLite('AdminRoomTypeGlobalDemand');
+
+                if ($this->_list['global_demands']) {
+                    $view = $helper->generateList($this->_list['global_demands'], $this->fields_list['global_demands']);
+                }
+
+                $this->tpl_view_vars['num_global_demands'] = count($this->_list['global_demands']);
+                $this->tpl_view_vars['global_demands'] = $view;
+            }
+
+            if (isset($this->_list['refund_rules']) && count($this->_list['refund_rules'])) {
+                $view = '';
+                $this->initRefundRuleList();
+
+                $helper = new HelperList();
+                $helper->shopLinkType = '';
+                $helper->simple_header = true;
+                $helper->identifier = 'id_refund_rule';
+                $helper->actions = array('edit');
+                $helper->show_toolbar = false;
+                $helper->table = 'htl_order_refund_rules';
+                $helper->currentIndex = $this->context->link->getAdminLink('AdminOrderRefundRules', false);
+                $helper->token = Tools::getAdminTokenLite('AdminOrderRefundRules');
+
+                if ($this->_list['refund_rules']) {
+                    $view = $helper->generateList($this->_list['refund_rules'], $this->fields_list['refund_rules']);
+                }
+
+                $this->tpl_view_vars['num_refund_rules'] = count($this->_list['refund_rules']);
+                $this->tpl_view_vars['refund_rules'] = $view;
+            }
+
             if (isset($this->_list['orders']) && count($this->_list['orders'])) {
                 $view = '';
                 $this->initOrderList();

--- a/modules/hotelreservationsystem/classes/HotelBranchInformation.php
+++ b/modules/hotelreservationsystem/classes/HotelBranchInformation.php
@@ -1028,19 +1028,21 @@ class HotelBranchInformation extends ObjectModel
         return false;
     }
 
-    public function getAccessibleHotelByName($name)
+    public function searchByName($query, $idEmployeeProfile, $idLang = false)
     {
-        $context = Context::getContext();
-        $idLang = $context->language->id;
-        $sql = ' SELECT a.`id`, a.`active`, hbl.`hotel_name`, aa.`city`, s.`name` as `state_name`, cl.`name` as `country_name`
+        if (!$idLang) {
+            $idLang = Context::getContext()->language->id;
+        }
+
+        $sql = 'SELECT a.`id`, a.`active`, hbl.`hotel_name`, aa.`city`, s.`name` AS `state_name`, cl.`name` AS `country_name`
             FROM `'._DB_PREFIX_.'htl_branch_info` a
             LEFT JOIN  `'._DB_PREFIX_.'htl_branch_info_lang` hbl ON hbl.`id` = a.`id` AND hbl.`id_lang` = '.(int)$idLang.'
             LEFT JOIN  `'._DB_PREFIX_.'address` aa ON aa.`id_hotel` = a.`id`
             LEFT JOIN `'._DB_PREFIX_.'state` s ON s.`id_state` = aa.`id_state`
             LEFT JOIN `'._DB_PREFIX_.'country_lang` cl ON cl.`id_country` = aa.`id_country` AND cl.`id_lang` = hbl.`id_lang`
             LEFT JOIN `'._DB_PREFIX_.'htl_access` ha ON a.`id` = ha.`id_hotel`
-            WHERE hbl.`hotel_name` LIKE \'%'.pSQL($name).'%\'
-            AND ha.`access`=1 AND ha.`id_profile` = '.(int)$context->employee->id_profile;
+            WHERE hbl.`hotel_name` LIKE \'%'.pSQL($query).'%\'
+            AND ha.`access`= 1 AND ha.`id_profile` = '.(int) $idEmployeeProfile;
 
         return Db::getInstance()->executeS($sql);
     }

--- a/modules/hotelreservationsystem/classes/HotelBranchInformation.php
+++ b/modules/hotelreservationsystem/classes/HotelBranchInformation.php
@@ -1027,4 +1027,22 @@ class HotelBranchInformation extends ObjectModel
 
         return false;
     }
+
+    public function getAccessibleHotelByName($name)
+    {
+        $context = Context::getContext();
+        $idLang = $context->language->id;
+        $sql = ' SELECT a.`id`, a.`active`, hbl.`hotel_name`, aa.`city`, s.`name` as `state_name`, cl.`name` as `country_name`
+            FROM `'._DB_PREFIX_.'htl_branch_info` a
+            LEFT JOIN  `'._DB_PREFIX_.'htl_branch_info_lang` hbl ON hbl.`id` = a.`id` AND hbl.`id_lang` = '.(int)$idLang.'
+            LEFT JOIN  `'._DB_PREFIX_.'address` aa ON aa.`id_hotel` = a.`id`
+            LEFT JOIN `'._DB_PREFIX_.'state` s ON s.`id_state` = aa.`id_state`
+            LEFT JOIN `'._DB_PREFIX_.'country_lang` cl ON cl.`id_country` = aa.`id_country` AND cl.`id_lang` = hbl.`id_lang`
+            LEFT JOIN `'._DB_PREFIX_.'htl_access` ha ON a.`id` = ha.`id_hotel`
+            WHERE hbl.`hotel_name` LIKE \'%'.pSQL($name).'%\'
+            AND ha.`access`=1 AND ha.`id_profile` = '.(int)$context->employee->id_profile;
+
+        return Db::getInstance()->executeS($sql);
+    }
+
 }

--- a/modules/hotelreservationsystem/classes/HotelFeatures.php
+++ b/modules/hotelreservationsystem/classes/HotelFeatures.php
@@ -207,4 +207,21 @@ class HotelFeatures extends ObjectModel
     {
         return Db::getInstance()->update('htl_features', $update_params, 'id='.(int) $parent_feature_id);
     }
+
+    public function searchHotelFeatureByName($name, $idLang = false)
+    {
+
+        if (!$idLang) {
+            $idLang = Context::getContext()->language->id;
+        }
+
+        return Db::getInstance()->executeS(
+            'SELECT hf.*, hfl.* FROM `'._DB_PREFIX_.'htl_features` hf
+            LEFT JOIN `'._DB_PREFIX_.'htl_features_lang` hfl
+            ON hfl.`id` = hf.`id`
+            WHERE hfl.`name` LIKE \'%'.pSQL($name).'%\'
+            AND `id_lang`='.(int)$idLang
+        );
+    }
+
 }

--- a/modules/hotelreservationsystem/classes/HotelFeatures.php
+++ b/modules/hotelreservationsystem/classes/HotelFeatures.php
@@ -208,9 +208,8 @@ class HotelFeatures extends ObjectModel
         return Db::getInstance()->update('htl_features', $update_params, 'id='.(int) $parent_feature_id);
     }
 
-    public function searchHotelFeatureByName($name, $idLang = false)
+    public function searchByName($query, $idLang = false)
     {
-
         if (!$idLang) {
             $idLang = Context::getContext()->language->id;
         }
@@ -219,9 +218,8 @@ class HotelFeatures extends ObjectModel
             'SELECT hf.*, hfl.* FROM `'._DB_PREFIX_.'htl_features` hf
             LEFT JOIN `'._DB_PREFIX_.'htl_features_lang` hfl
             ON hfl.`id` = hf.`id`
-            WHERE hfl.`name` LIKE \'%'.pSQL($name).'%\'
-            AND `id_lang`='.(int)$idLang
+            WHERE hfl.`name` LIKE \'%'.pSQL($query).'%\'
+            AND hfl.`id_lang`='.(int) $idLang
         );
     }
-
 }

--- a/modules/hotelreservationsystem/classes/HotelOrderRefundRules.php
+++ b/modules/hotelreservationsystem/classes/HotelOrderRefundRules.php
@@ -267,4 +267,21 @@ class HotelOrderRefundRules extends ObjectModel
         return array();
 
     }
+
+    public function searchOrderRefundRulesByName($name, $idLang = false)
+    {
+
+        if (!$idLang) {
+            $idLang = Context::getContext()->language->id;
+        }
+
+        return Db::getInstance()->executeS(
+            'SELECT horr.*, horrl.* FROM `'._DB_PREFIX_.'htl_order_refund_rules` horr
+            LEFT JOIN `'._DB_PREFIX_.'htl_order_refund_rules_lang` horrl
+            ON horrl.`id_refund_rule` = horr.`id_refund_rule`
+            WHERE (horrl.`name` LIKE \'%'.pSQL($name).'%\' OR horrl.`description` LIKE \'%'.pSQL($name).'%\')
+            AND `id_lang`='.(int)$idLang
+        );
+    }
+
 }

--- a/modules/hotelreservationsystem/classes/HotelOrderRefundRules.php
+++ b/modules/hotelreservationsystem/classes/HotelOrderRefundRules.php
@@ -268,9 +268,8 @@ class HotelOrderRefundRules extends ObjectModel
 
     }
 
-    public function searchOrderRefundRulesByName($name, $idLang = false)
+    public function searchByName($query, $idLang = false)
     {
-
         if (!$idLang) {
             $idLang = Context::getContext()->language->id;
         }
@@ -279,8 +278,11 @@ class HotelOrderRefundRules extends ObjectModel
             'SELECT horr.*, horrl.* FROM `'._DB_PREFIX_.'htl_order_refund_rules` horr
             LEFT JOIN `'._DB_PREFIX_.'htl_order_refund_rules_lang` horrl
             ON horrl.`id_refund_rule` = horr.`id_refund_rule`
-            WHERE (horrl.`name` LIKE \'%'.pSQL($name).'%\' OR horrl.`description` LIKE \'%'.pSQL($name).'%\')
-            AND `id_lang`='.(int)$idLang
+            WHERE (
+                horrl.`name` LIKE \'%'.pSQL($query).'%\' OR
+                horrl.`description` LIKE \'%'.pSQL($query).'%\'
+            )
+            AND horrl.`id_lang`='.(int) $idLang
         );
     }
 

--- a/modules/hotelreservationsystem/classes/HotelRoomTypeGlobalDemand.php
+++ b/modules/hotelreservationsystem/classes/HotelRoomTypeGlobalDemand.php
@@ -152,4 +152,26 @@ class HotelRoomTypeGlobalDemand extends ObjectModel
             'SELECT `id_option` as `id` FROM `'._DB_PREFIX_.'htl_room_type_global_demand_advance_option` WHERE `id_global_demand` = '.(int)$this->id.' ORDER BY `id` ASC'
         );
     }
+
+
+    public function searchRoomTypeDemandsByName($name, $idLang = false)
+    {
+        if (!$idLang) {
+            $idLang = Context::getContext()->language->id;
+        }
+
+        return Db::getInstance()->executeS(
+            'SELECT rtgd.*, rtgdl.*, rtgdao.`price` AS `option_price`, rtgdaol.`name` AS `option_name`
+            FROM `'._DB_PREFIX_.'htl_room_type_global_demand` rtgd
+            LEFT JOIN `'._DB_PREFIX_.'htl_room_type_global_demand_lang` rtgdl
+            ON rtgdl.`id_global_demand` = rtgd.`id_global_demand`
+            LEFT JOIN `'._DB_PREFIX_.'htl_room_type_global_demand_advance_option` rtgdao
+                ON rtgdao.`id_global_demand` = rtgd.`id_global_demand`
+            LEFT JOIN `'._DB_PREFIX_.'htl_room_type_global_demand_advance_option_lang` rtgdaol
+            ON (rtgdaol.`id_option` = rtgdao.`id_option` AND rtgdl.`id_lang` = rtgdaol.`id_lang`)
+            WHERE (rtgdl.`name` LIKE \'%'.pSQL($name).'%\' OR rtgdaol.`name` LIKE \'%'.pSQL($name).'%\' )
+            AND rtgdl.`id_lang`='.(int)$idLang
+        );
+    }
+
 }

--- a/modules/hotelreservationsystem/classes/HotelRoomTypeGlobalDemand.php
+++ b/modules/hotelreservationsystem/classes/HotelRoomTypeGlobalDemand.php
@@ -154,23 +154,26 @@ class HotelRoomTypeGlobalDemand extends ObjectModel
     }
 
 
-    public function searchRoomTypeDemandsByName($name, $idLang = false)
+    public function searchByName($query, $idLang = false)
     {
         if (!$idLang) {
             $idLang = Context::getContext()->language->id;
         }
 
-        return Db::getInstance()->executeS(
-            'SELECT rtgd.*, rtgdl.*, rtgdao.`price` AS `option_price`, rtgdaol.`name` AS `option_name`
+        return Db::getInstance()->executeS('
+            SELECT rtgd.*, rtgdl.*, rtgdao.`price` AS `option_price`, rtgdaol.`name` AS `option_name`
             FROM `'._DB_PREFIX_.'htl_room_type_global_demand` rtgd
             LEFT JOIN `'._DB_PREFIX_.'htl_room_type_global_demand_lang` rtgdl
-            ON rtgdl.`id_global_demand` = rtgd.`id_global_demand`
+                ON rtgdl.`id_global_demand` = rtgd.`id_global_demand`
             LEFT JOIN `'._DB_PREFIX_.'htl_room_type_global_demand_advance_option` rtgdao
                 ON rtgdao.`id_global_demand` = rtgd.`id_global_demand`
             LEFT JOIN `'._DB_PREFIX_.'htl_room_type_global_demand_advance_option_lang` rtgdaol
-            ON (rtgdaol.`id_option` = rtgdao.`id_option` AND rtgdl.`id_lang` = rtgdaol.`id_lang`)
-            WHERE (rtgdl.`name` LIKE \'%'.pSQL($name).'%\' OR rtgdaol.`name` LIKE \'%'.pSQL($name).'%\' )
-            AND rtgdl.`id_lang`='.(int)$idLang
+                ON (rtgdaol.`id_option` = rtgdao.`id_option` AND rtgdl.`id_lang` = rtgdaol.`id_lang`)
+            WHERE (
+                rtgdl.`name` LIKE \'%'.pSQL($query).'%\' OR
+                rtgdaol.`name` LIKE \'%'.pSQL($query).'%\'
+            )
+            AND rtgdl.`id_lang`='.(int) $idLang
         );
     }
 


### PR DESCRIPTION
Added controller wise permissions to the search results, for example: only the employees having the access to room types will be able view the room types in search result.
Added the following in the search results:
**- Hotels:** hotels can be searched using the name, or admin can select newly added search type hotel and can open edit hotel page by using a valid id_hotel.
**- Service products:** Admin can search service products using the name, or admin can select search type catalog and can  open edit service product page by using a valid service id_product.
**- Customer addresses:** Admin can search customers addresses using city, state, country, alias, address1, postcode, etc.
**- Customer messages:** Admin can search customer message, in case a message belongs to an order then it will restricted by hotel wise employee permission,  whereas the messages that is sent from the contact us page will be displayed to all the employees.
**- Global demands:** Admin will now get Additional facilities in the search page results and Admin can search additional facilities using their name only.
**- Hotel Features:** Admin will now get hotel features in the search page results and Admin can search hotel facilities using their name only.
**- Refund rules:**  Admin will now get refund rules in the search page results.