### PR TITLE
Fixed: PHP issue on customer order detail page on room reallocation to another room type

### DIFF
--- a/modules/hotelreservationsystem/classes/HotelBookingDetail.php
+++ b/modules/hotelreservationsystem/classes/HotelBookingDetail.php
@@ -1787,6 +1787,7 @@ class HotelBookingDetail extends ObjectModel
 
                 // change product name in order detail table
                 $objOrderDetail = new OrderDetail((int) $objHotelBooking->id_order_detail);
+                $objOrderDetail->product_id = $idNewRoomType;
                 $objOrderDetail->product_name = $objProduct->name;
 
                 // manage the prices in the order tables for the price diffrence


### PR DESCRIPTION
This issue is caused because `id_product` is not updated in `order_detail` table.