### PR TITLE
 Fixed: Validation messages should be present on the view page on admin order detail page for Document Notes.

### DIFF
--- a/admin/themes/default/template/controllers/orders/modals/_document_note.tpl
+++ b/admin/themes/default/template/controllers/orders/modals/_document_note.tpl
@@ -18,7 +18,7 @@
 *}
 
 <div class="modal-body">
-    <form  action="{$current_index}&amp;viewOrder&amp;id_order={$order->id}{if isset($smarty.get.token)}&amp;token={$smarty.get.token|escape:'html':'UTF-8'}{/if}" method="post">
+    <form  action="{$current_index}&amp;vieworder&amp;id_order={$order->id}{if isset($smarty.get.token)}&amp;token={$smarty.get.token|escape:'html':'UTF-8'}{/if}" method="post">
         <div class="form-group">
             <label class="control-label">{l s='Note Detail'}</label>
             <input type="hidden" name="id_order_invoice" id="id_order_invoice" value="" />

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -1648,16 +1648,20 @@ class AdminOrdersControllerCore extends AdminController
         } elseif (Tools::isSubmit('submitEditNote')) {
             $note = Tools::getValue('note');
             $order_invoice = new OrderInvoice((int)Tools::getValue('id_order_invoice'));
-            if (Validate::isLoadedObject($order_invoice) && Validate::isCleanHtml($note)) {
-                if ($this->tabAccess['edit'] === '1') {
-                    $order_invoice->note = $note;
-                    if ($order_invoice->save()) {
-                        Tools::redirectAdmin(self::$currentIndex.'&id_order='.$order_invoice->id_order.'&vieworder&conf=4&token='.$this->token);
+            if (Validate::isLoadedObject($order_invoice)) {
+                if (Validate::isCleanHtml($note)) {
+                    if ($this->tabAccess['edit'] === '1') {
+                        $order_invoice->note = $note;
+                        if ($order_invoice->save()) {
+                            Tools::redirectAdmin(self::$currentIndex.'&id_order='.$order_invoice->id_order.'&vieworder&conf=4&token='.$this->token);
+                        } else {
+                            $this->errors[] = Tools::displayError('The invoice note was not saved.');
+                        }
                     } else {
-                        $this->errors[] = Tools::displayError('The invoice note was not saved.');
+                        $this->errors[] = Tools::displayError('You do not have permission to edit this.');
                     }
                 } else {
-                    $this->errors[] = Tools::displayError('You do not have permission to edit this.');
+                    $this->errors[] = Tools::displayError('Invaid note found.');
                 }
             } else {
                 $this->errors[] = Tools::displayError('The invoice for edit note was unable to load. ');

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -1661,7 +1661,7 @@ class AdminOrdersControllerCore extends AdminController
                         $this->errors[] = Tools::displayError('You do not have permission to edit this.');
                     }
                 } else {
-                    $this->errors[] = Tools::displayError('Invaid note found.');
+                    $this->errors[] = Tools::displayError('Invalid note found.');
                 }
             } else {
                 $this->errors[] = Tools::displayError('The invoice for edit note was unable to load. ');


### PR DESCRIPTION
Fixed: Validation messages should be present on the view page on admin order detail page for Document Notes.
Improved : Validation messages for invalid note