### PR TITLE
Fixed: Issues if admin tries to add discount having values equals or greater to the order total or due amount.

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -374,7 +374,7 @@ class CartCore extends ObjectModel
         if ($cart_vat_amount == 0 || $cart_amount_te == 0) {
             return 0;
         } else {
-            return Tools::ps_round($cart_vat_amount / $cart_amount_te, 3);
+            return Tools::ps_round($cart_vat_amount / $cart_amount_te, 6);
         }
     }
 

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -797,8 +797,9 @@ class OrderCore extends ObjectModel
 
     public function getTaxesAverageUsed()
     {
-        // @todo should use order table to get tax average
-        return Cart::getTaxesAverageUsed((int)$this->id_cart);
+        $cart = new Cart((int) $this->id_cart);
+
+        return $cart->getAverageProductsTaxRate() * 100;
     }
 
     /**


### PR DESCRIPTION
- Fixed: Getting fatal error if admin tries to add coupon having values equal to the order total in back-office.
- Fixed: Should get validation while adding a coupon in the order if its value is greater than the due amount in the back-office.
- Fixed: Tax is not calculated correctly after applying a discount on the order by the admin