### PR TITLE
Updated: Revert PR #789 and display occupancy on room type detail page using referer

### DIFF
--- a/controllers/front/CategoryController.php
+++ b/controllers/front/CategoryController.php
@@ -181,22 +181,6 @@ class CategoryControllerCore extends FrontController
 
             $booking_data = $objBookingDetail->dataForFrontSearch($bookingParams);
 
-            // set default occupancies in required format
-            if (isset($booking_data['rm_data']) && $booking_data['rm_data']) {
-                foreach ($booking_data['rm_data'] as &$roomTypeData) {
-                    $occupancy = array(
-                        array(
-                            'adults' => $roomTypeData['adults'],
-                            'children' => 0,
-                            'child_ages' => array(),
-                        ),
-                    );
-
-                    $roomTypeData['occupancies'] = $occupancy;
-                    $roomTypeData['occupancy_adults'] = $roomTypeData['adults']; // only one room by default
-                }
-            }
-
             $obj_booking_detail = new HotelBookingDetail();
             $num_days = $obj_booking_detail->getNumberOfDays($date_from, $date_to);
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -427,14 +427,27 @@ class ProductControllerCore extends FrontController
                     if (Configuration::get('PS_FRONT_ROOM_UNIT_SELECTION_TYPE') == HotelBookingDetail::PS_ROOM_UNIT_SELECTION_TYPE_QUANTITY) {
                         $occupancy_value = 1;
                     } else {
-                        $occupancy_value = array(
-                            array(
-                                'adults' => $room_info_by_product_id['adults'],
-                                'children' => 0,
-                                'child_ages' => array(),
-                            ),
-                        );
+                        $useDefaultOccupancy = true;
+                        // if coming from hotel page do not set occupancy, otherwise set base adult occupancy
+                        if (isset($_SERVER['HTTP_REFERER']) && $_SERVER['HTTP_REFERER'] == Tools::secureReferrer($_SERVER['HTTP_REFERER'])) { // Assure us the previous page was one of the site
+                            $idCategoryHotel = $hotel_branch_obj->id_category;
+                            $categoryPageLink = $this->context->link->getCategoryLink($idCategoryHotel);
+                            if (Tools::strpos($_SERVER['HTTP_REFERER'], $categoryPageLink) === 0) {
+                                $useDefaultOccupancy = false;
+                            }
+                        }
+
+                        if ($useDefaultOccupancy) {
+                            $occupancy_value = array(
+                                array(
+                                    'adults' => $room_info_by_product_id['adults'],
+                                    'children' => 0,
+                                    'child_ages' => array(),
+                                ),
+                            );
+                        }
                     }
+
                     $this->assignBookingFormVars($this->product->id, $date_from, $date_to, $occupancy_value);
                     $this->assignServiceProductVars();
 

--- a/js/admin/orders.js
+++ b/js/admin/orders.js
@@ -2515,13 +2515,6 @@ const AddRoomBookingModal = {
                                     $('#new_product .booking_guest_occupancy').removeClass('disabled');
                                     setRoomTypeGuestOccupancy($('#new_product .booking_occupancy_wrapper'));
                                 }
-                                if (data.room_type_info) {
-                                    $('#new_product .max_adults').val(data.room_type_info.max_adults);
-                                    $('#new_product .max_children').val(data.room_type_info.max_children);
-                                    $('#new_product .max_guests').val(data.room_type_info.max_guests);
-                                    $('#new_product .num_adults').attr('max', data.room_type_info.max_adults);
-                                    $('#new_product .num_children').attr('max', data.room_type_info.max_children);
-                                }
 
                                 // Keep product variable
                                 current_product = data;

--- a/modules/blockcart/ajax-cart.js
+++ b/modules/blockcart/ajax-cart.js
@@ -478,6 +478,9 @@ var ajaxCart = {
                     else
                         $(callerElement).removeProp('disabled');
                 }
+                if (!addedFromProductPage) {
+                    resetOccupancyField($(callerElement).closest('.booking_room_fields').find('.booking_occupancy_wrapper'));
+                }
                 emptyCustomizations();
 
             },

--- a/modules/hotelreservationsystem/controllers/admin/AdminHotelRoomsBookingController.php
+++ b/modules/hotelreservationsystem/controllers/admin/AdminHotelRoomsBookingController.php
@@ -819,19 +819,6 @@ class AdminHotelRoomsBookingController extends ModuleAdminController
             $objHotelRoomType = new HotelRoomType();
             foreach ($booking_data['rm_data'] as $key_bk_data => $value_bk_data) {
                 $booking_data['rm_data'][$key_bk_data]['room_type_info'] = $objHotelRoomType->getRoomTypeInfoByIdProduct($value_bk_data['id_product']);
-
-                // set default occupancies in required format
-                $occupancy = array(
-                    array(
-                        'adults' => $value_bk_data['adults'],
-                        'children' => 0,
-                        'child_ages' => array(),
-                    ),
-                );
-
-                $booking_data['rm_data'][$key_bk_data]['occupancies'] = $occupancy;
-                $booking_data['rm_data'][$key_bk_data]['occupancy_adults'] = $booking_data['rm_data'][$key_bk_data]['adults']; // only one room by default
-
                 if (isset($value_bk_data['data']['booked']) && $value_bk_data['data']['booked']) {
                     foreach ($value_bk_data['data']['booked'] as $booked_k1 => $booked_v1) {
                         if (isset($booked_v1['detail']) && $booked_v1['detail']) {

--- a/modules/hotelreservationsystem/views/templates/admin/hotel_rooms_booking/helpers/view/_partials/booking-rooms.tpl
+++ b/modules/hotelreservationsystem/views/templates/admin/hotel_rooms_booking/helpers/view/_partials/booking-rooms.tpl
@@ -56,79 +56,40 @@
                                                     <td class="booking_occupancy">
                                                         <div class="dropdown">
                                                             <button class="btn btn-default btn-left btn-block booking_guest_occupancy input-occupancy" type="button">
-                                                                <span>
-                                                                    {if isset($book_v['occupancies']) && $book_v['occupancies']}
-                                                                        {if (isset($book_v['occupancy_adults']) && $book_v['occupancy_adults'])}{$book_v['occupancy_adults']} {if $book_v['occupancy_adults'] > 1}{l s='Adults' mod='hotelreservationsystem'}{else}{l s='Adult' mod='hotelreservationsystem'}{/if}, {if isset($book_v['occupancy_children']) && $book_v['occupancy_children']}{$book_v['occupancy_children']} {if $book_v['occupancy_children'] > 1} {l s='Children' mod='hotelreservationsystem'}{else}{l s='Child' mod='hotelreservationsystem'}{/if}, {/if}{$book_v['occupancies']|count} {if $book_v['occupancies']|count > 1}{l s='Rooms' mod='hotelreservationsystem'}{else}{l s='Room' mod='hotelreservationsystem'}{/if}{else}{l s='1 Adult, 1 Room' mod='hotelreservationsystem'}{/if}
-                                                                    {else}
-                                                                        {l s='Select occupancy' mod='hotelreservationsystem'}
-                                                                    {/if}
-                                                                </span>
+                                                                <span>{l s='Select occupancy' mod='hotelreservationsystem'}</span>
                                                             </button>
                                                             <div class="dropdown-menu booking_occupancy_wrapper well well-sm">
                                                                 <input type="hidden" class="max_adults" value="{if isset($book_v)}{$book_v['max_adults']|escape:'html':'UTF-8'}{/if}">
                                                                 <input type="hidden" class="max_children" value="{if isset($book_v)}{$book_v['max_children']|escape:'html':'UTF-8'}{/if}">
                                                                 <input type="hidden" class="max_guests" value="{if isset($book_v)}{$book_v['max_guests']|escape:'html':'UTF-8'}{/if}">
                                                                 <div class="booking_occupancy_inner row">
-                                                                    {if isset($book_v['occupancies']) && $book_v['occupancies']}
-                                                                        {assign var=countRoom value=1}
-                                                                        {foreach from=$book_v['occupancies'] key=key item=$occupancy name=occupancyInfo}
-                                                                            <div class="occupancy_info_block selected col-sm-12" occ_block_index="0">
-                                                                                <div class="occupancy_info_head col-sm-12"><label class="room_num_wrapper">{l s='Room - 1' mod='hotelreservationsystem'}</label></div>
-                                                                                <div class="col-sm-12">
-                                                                                    <div class="row">
-                                                                                        <div class="form-group col-xs-6 occupancy_count_block">
-                                                                                            <label>{l s='Adults' mod='hotelreservationsystem'}</label>
-                                                                                            <input type="number" class="form-control num_occupancy num_adults" name="occupancy[{$key|escape:'htmlall':'UTF-8'}][adults]" value="{$occupancy['adults']|escape:'htmlall':'UTF-8'}" min="1"  data-max="{if isset($book_v)}{$book_v['max_adults']|escape:'html':'UTF-8'}{/if}">
-                                                                                        </div>
-                                                                                        <div class="form-group col-xs-6 occupancy_count_block">
-                                                                                            <label>{l s='Children' mod='hotelreservationsystem'} <span class="label-desc-txt"></span></label>
-                                                                                            <input type="number" class="form-control num_occupancy num_children" name="occupancy[{$key|escape:'htmlall':'UTF-8'}][children]" value="{$occupancy['children']|escape:'htmlall':'UTF-8'}" min="0" data-max="{if isset($book_v)}{$book_v['max_children']|escape:'html':'UTF-8'}{else}{$max_child_in_room}{/if}">
-                                                                                            ({l s='Below' mod='hotelreservationsystem'}  {$max_child_age|escape:'htmlall':'UTF-8'} {l s='years' mod='hotelreservationsystem'})
-                                                                                        </div>
-                                                                                    </div>
-                                                                                    <p style="display:none;"><span class="text-danger occupancy-input-errors"></span></p>
-                                                                                    <div class="row children_age_info_block" style="display:none">
-                                                                                        <div class="form-group col-sm-12">
-                                                                                            <label class="">{l s='All Children' mod='hotelreservationsystem'}</label>
-                                                                                            <div class="">
-                                                                                                <div class="row children_ages">
-                                                                                                </div>
-                                                                                            </div>
+                                                                    <div class="occupancy_info_block col-sm-12" occ_block_index="0">
+                                                                        <div class="occupancy_info_head col-sm-12"><label class="room_num_wrapper">{l s='Room - 1' mod='hotelreservationsystem'}</label></div>
+                                                                        <div class="col-sm-12">
+                                                                            <div class="row">
+                                                                                <div class="form-group col-xs-6 occupancy_count_block">
+                                                                                    <label>{l s='Adults' mod='hotelreservationsystem'}</label>
+                                                                                    <input type="number" class="form-control num_occupancy num_adults" name="occupancy[0][adults]" value="1" min="1"  data-max="{if isset($book_v)}{$book_v['max_adults']|escape:'html':'UTF-8'}{/if}">
+                                                                                </div>
+                                                                                <div class="form-group col-xs-6 occupancy_count_block">
+                                                                                    <label>{l s='Children' mod='hotelreservationsystem'} <span class="label-desc-txt"></span></label>
+                                                                                    <input type="number" class="form-control num_occupancy num_children" name="occupancy[0][children]" value="0" min="0" data-max="{if isset($book_v)}{$book_v['max_children']|escape:'html':'UTF-8'}{else}{$max_child_in_room}{/if}">
+                                                                                    ({l s='Below' mod='hotelreservationsystem'}  {$max_child_age|escape:'htmlall':'UTF-8'} {l s='years' mod='hotelreservationsystem'})
+                                                                                </div>
+                                                                            </div>
+                                                                            <p style="display:none;"><span class="text-danger occupancy-input-errors"></span></p>
+                                                                            <div class="row children_age_info_block" style="display:none">
+                                                                                <div class="form-group col-sm-12">
+                                                                                    <label class="">{l s='All Children' mod='hotelreservationsystem'}</label>
+                                                                                    <div class="">
+                                                                                        <div class="row children_ages">
                                                                                         </div>
                                                                                     </div>
                                                                                 </div>
                                                                             </div>
-                                                                            {assign var=countRoom value=$countRoom+1}
-                                                                        {/foreach}
-                                                                    {else}
-                                                                        <div class="occupancy_info_block col-sm-12" occ_block_index="0">
-                                                                            <div class="occupancy_info_head col-sm-12"><label class="room_num_wrapper">{l s='Room - 1' mod='hotelreservationsystem'}</label></div>
-                                                                            <div class="col-sm-12">
-                                                                                <div class="row">
-                                                                                    <div class="form-group col-xs-6 occupancy_count_block">
-                                                                                        <label>{l s='Adults' mod='hotelreservationsystem'}</label>
-                                                                                        <input type="number" class="form-control num_occupancy num_adults" name="occupancy[0][adults]" value="1" min="1"  max="{if isset($book_v)}{$book_v['max_adults']|escape:'html':'UTF-8'}{/if}">
-                                                                                    </div>
-                                                                                    <div class="form-group col-xs-6 occupancy_count_block">
-                                                                                        <label>{l s='Children' mod='hotelreservationsystem'} <span class="label-desc-txt"></span></label>
-                                                                                        <input type="number" class="form-control num_occupancy num_children" name="occupancy[0][children]" value="0" min="0" max="{if isset($book_v)}{$book_v['max_children']|escape:'html':'UTF-8'}{else}{$max_child_in_room}{/if}">
-                                                                                        ({l s='Below'}  {$max_child_age|escape:'htmlall':'UTF-8'} {l s='years' mod='hotelreservationsystem'})
-                                                                                    </div>
-                                                                                </div>
-                                                                                <p style="display:none;"><span class="text-danger occupancy-input-errors"></span></p>
-                                                                                <div class="row children_age_info_block" style="display:none">
-                                                                                    <div class="form-group col-sm-12">
-                                                                                        <label class="">{l s='All Children' mod='hotelreservationsystem'}</label>
-                                                                                        <div class="">
-                                                                                            <div class="row children_ages">
-                                                                                            </div>
-                                                                                        </div>
-                                                                                    </div>
-                                                                                </div>
-                                                                            </div>
-                                                                            {* <hr class="occupancy-info-separator"> *}
                                                                         </div>
-                                                                    {/if}
+                                                                        {* <hr class="occupancy-info-separator"> *}
+                                                                    </div>
                                                                 </div>
                                                                 {* <div class="add_occupancy_block">
                                                                     <a class="add_new_occupancy_btn" href="#"><i class="icon-plus"></i> <span>{l s='Add Room'}</span></a>
@@ -183,79 +144,40 @@
                                                         <td class="booking_occupancy">
                                                             <div class="dropdown">
                                                                 <button class="btn btn-default btn-left btn-block booking_guest_occupancy input-occupancy" type="button">
-                                                                    <span>
-                                                                        {if isset($book_v['occupancies']) && $book_v['occupancies']}
-                                                                            {if (isset($book_v['occupancy_adults']) && $book_v['occupancy_adults'])}{$book_v['occupancy_adults']} {if $book_v['occupancy_adults'] > 1}{l s='Adults' mod='hotelreservationsystem'}{else}{l s='Adult' mod='hotelreservationsystem'}{/if}, {if isset($book_v['occupancy_children']) && $book_v['occupancy_children']}{$book_v['occupancy_children']} {if $book_v['occupancy_children'] > 1} {l s='Children' mod='hotelreservationsystem'}{else}{l s='Child' mod='hotelreservationsystem'}{/if}, {/if}{$book_v['occupancies']|count} {if $book_v['occupancies']|count > 1}{l s='Rooms' mod='hotelreservationsystem'}{else}{l s='Room' mod='hotelreservationsystem'}{/if}{else}{l s='1 Adult, 1 Room' mod='hotelreservationsystem'}{/if}
-                                                                        {else}
-                                                                            {l s='Select occupancy' mod='hotelreservationsystem'}
-                                                                        {/if}
-                                                                    </span>
+                                                                    <span>{l s='Select occupancy' mod='hotelreservationsystem'}</span>
                                                                 </button>
                                                                 <div class="dropdown-menu booking_occupancy_wrapper well well-sm">
                                                                     <input type="hidden" class="max_adults" value="{if isset($book_v)}{$book_v['max_adults']|escape:'html':'UTF-8'}{/if}">
                                                                     <input type="hidden" class="max_children" value="{if isset($book_v)}{$book_v['max_children']|escape:'html':'UTF-8'}{/if}">
                                                                     <input type="hidden" class="max_guests" value="{if isset($book_v)}{$book_v['max_guests']|escape:'html':'UTF-8'}{/if}">
                                                                     <div class="booking_occupancy_inner row">
-                                                                        {if isset($book_v['occupancies']) && $book_v['occupancies']}
-                                                                            {assign var=countRoom value=1}
-                                                                            {foreach from=$book_v['occupancies'] key=key item=$occupancy name=occupancyInfo}
-                                                                                <div class="occupancy_info_block selected col-sm-12" occ_block_index="0">
-                                                                                    <div class="occupancy_info_head col-sm-12"><label class="room_num_wrapper">{l s='Room - 1' mod='hotelreservationsystem'}</label></div>
-                                                                                    <div class="col-sm-12">
-                                                                                        <div class="row">
-                                                                                            <div class="form-group col-xs-6 occupancy_count_block">
-                                                                                                <label>{l s='Adults' mod='hotelreservationsystem'}</label>
-                                                                                                <input type="number" class="form-control num_occupancy num_adults" name="occupancy[{$key|escape:'htmlall':'UTF-8'}][adults]" value="{$occupancy['adults']|escape:'htmlall':'UTF-8'}" min="1"  data-max="{if isset($book_v)}{$book_v['max_adults']|escape:'html':'UTF-8'}{/if}">
-                                                                                            </div>
-                                                                                            <div class="form-group col-xs-6 occupancy_count_block">
-                                                                                                <label>{l s='Children' mod='hotelreservationsystem'} <span class="label-desc-txt"></span></label>
-                                                                                                <input type="number" class="form-control num_occupancy num_children" name="occupancy[{$key|escape:'htmlall':'UTF-8'}][children]" value="{$occupancy['children']|escape:'htmlall':'UTF-8'}" min="0" data-max="{if isset($book_v)}{$book_v['max_children']|escape:'html':'UTF-8'}{else}{$max_child_in_room}{/if}">
-                                                                                                ({l s='Below' mod='hotelreservationsystem'}  {$max_child_age|escape:'htmlall':'UTF-8'} {l s='years' mod='hotelreservationsystem'})
-                                                                                            </div>
-                                                                                        </div>
-                                                                                        <p style="display:none;"><span class="text-danger occupancy-input-errors"></span></p>
-                                                                                        <div class="row children_age_info_block" style="display:none">
-                                                                                            <div class="form-group col-sm-12">
-                                                                                                <label class="">{l s='All Children' mod='hotelreservationsystem'}</label>
-                                                                                                <div class="">
-                                                                                                    <div class="row children_ages">
-                                                                                                    </div>
-                                                                                                </div>
+                                                                        <div class="occupancy_info_block col-sm-12" occ_block_index="0">
+                                                                            <div class="occupancy_info_head col-sm-12"><label class="room_num_wrapper">{l s='Room - 1' mod='hotelreservationsystem'}</label></div>
+                                                                            <div class="col-sm-12">
+                                                                                <div class="row">
+                                                                                    <div class="form-group col-xs-6 occupancy_count_block">
+                                                                                        <label>{l s='Adults' mod='hotelreservationsystem'}</label>
+                                                                                        <input type="number" class="form-control num_occupancy num_adults" name="occupancy[0][adults]" value="1" min="1"  data-max="{if isset($book_v)}{$book_v['max_adults']|escape:'html':'UTF-8'}{/if}">
+                                                                                    </div>
+                                                                                    <div class="form-group col-xs-6 occupancy_count_block">
+                                                                                        <label>{l s='Children' mod='hotelreservationsystem'} <span class="label-desc-txt"></span></label>
+                                                                                        <input type="number" class="form-control num_occupancy num_children" name="occupancy[0][children]" value="0" min="0" data-max="{if isset($book_v)}{$book_v['max_children']|escape:'html':'UTF-8'}{else}{$max_child_in_room}{/if}">
+                                                                                        ({l s='Below'}  {$max_child_age|escape:'htmlall':'UTF-8'} {l s='years' mod='hotelreservationsystem'})
+                                                                                    </div>
+                                                                                </div>
+                                                                                <p style="display:none;"><span class="text-danger occupancy-input-errors"></span></p>
+                                                                                <div class="row children_age_info_block" style="display:none">
+                                                                                    <div class="form-group col-sm-12">
+                                                                                        <label class="">{l s='All Children' mod='hotelreservationsystem'}</label>
+                                                                                        <div class="">
+                                                                                            <div class="row children_ages">
                                                                                             </div>
                                                                                         </div>
                                                                                     </div>
                                                                                 </div>
-                                                                                {assign var=countRoom value=$countRoom+1}
-                                                                            {/foreach}
-                                                                        {else}
-                                                                            <div class="occupancy_info_block col-sm-12" occ_block_index="0">
-                                                                                <div class="occupancy_info_head col-sm-12"><label class="room_num_wrapper">{l s='Room - 1' mod='hotelreservationsystem'}</label></div>
-                                                                                <div class="col-sm-12">
-                                                                                    <div class="row">
-                                                                                        <div class="form-group col-xs-6 occupancy_count_block">
-                                                                                            <label>{l s='Adults' mod='hotelreservationsystem'}</label>
-                                                                                            <input type="number" class="form-control num_occupancy num_adults" name="occupancy[0][adults]" value="1" min="1"  data-max="{if isset($book_v)}{$book_v['max_adults']|escape:'html':'UTF-8'}{/if}">
-                                                                                        </div>
-                                                                                        <div class="form-group col-xs-6 occupancy_count_block">
-                                                                                            <label>{l s='Children' mod='hotelreservationsystem'} <span class="label-desc-txt"></span></label>
-                                                                                            <input type="number" class="form-control num_occupancy num_children" name="occupancy[0][children]" value="0" data-max="{if isset($book_v)}{$book_v['max_children']|escape:'html':'UTF-8'}{else}{$max_child_in_room}{/if}">
-                                                                                            ({l s='Below' mod='hotelreservationsystem'}  {$max_child_age|escape:'htmlall':'UTF-8'} {l s='years' mod='hotelreservationsystem'})
-                                                                                        </div>
-                                                                                    </div>
-                                                                                    <p style="display:none;"><span class="text-danger occupancy-input-errors"></span></p>
-                                                                                    <div class="row children_age_info_block" style="display:none">
-                                                                                        <div class="form-group col-sm-12">
-                                                                                            <label class="">{l s='All Children' mod='hotelreservationsystem'}</label>
-                                                                                            <div class="">
-                                                                                                <div class="row children_ages">
-                                                                                                </div>
-                                                                                            </div>
-                                                                                        </div>
-                                                                                    </div>
-                                                                                </div>
-                                                                                {* <hr class="occupancy-info-separator"> *}
                                                                             </div>
-                                                                        {/if}
+                                                                            {* <hr class="occupancy-info-separator"> *}
+                                                                        </div>
                                                                     </div>
                                                                     {* <div class="add_occupancy_block">
                                                                         <a class="add_new_occupancy_btn" href="#"><i class="icon-plus"></i> <span>{l s='Add Room'}</span></a>

--- a/themes/hotel-reservation-theme/_partials/room_type_list.tpl
+++ b/themes/hotel-reservation-theme/_partials/room_type_list.tpl
@@ -79,8 +79,6 @@
 									{if !isset($restricted_country_mode) && !$PS_CATALOG_MODE && !$order_date_restrict}
 										{if isset($occupancy_required_for_booking) && $occupancy_required_for_booking}
 											<div class="booking_guest_occupancy_conatiner">
-												{assign var=occupancies value=$room_v['occupancies']}
-												{assign var=occupancy_adults value=$room_v['occupancy_adults']}
 												{include file="./occupancy_field.tpl" room_type_info=$room_v total_available_rooms=$room_v['room_left']}
 											</div>
 										{else}

--- a/themes/hotel-reservation-theme/js/modules/blockcart/ajax-cart.js
+++ b/themes/hotel-reservation-theme/js/modules/blockcart/ajax-cart.js
@@ -478,6 +478,9 @@ var ajaxCart = {
                     else
                         $(callerElement).removeProp('disabled');
                 }
+                if (!addedFromProductPage) {
+                    resetOccupancyField($(callerElement).closest('.booking_room_fields').find('.booking_occupancy_wrapper'));
+                }
                 emptyCustomizations();
 
             },

--- a/themes/hotel-reservation-theme/js/occupancy.js
+++ b/themes/hotel-reservation-theme/js/occupancy.js
@@ -380,3 +380,19 @@ function getRoomTypeGuestOccupancyFormated(adults, children, rooms)
 	return guestButtonVal;
 }
 
+
+function resetOccupancyField(booking_occupancy_wrapper)
+{
+	$(booking_occupancy_wrapper).siblings('.booking_guest_occupancy').find('span').text(select_occupancy_txt);
+	$(booking_occupancy_wrapper).find('.booking_occupancy_inner > div').each(function(index, element){
+		let num_adults = $(booking_occupancy_wrapper).find('.base_adult').val();
+		if (index == 0) {
+			$(this).removeClass('selected');
+			$(this).find('.num_adults').val(num_adults).siblings('.occupancy_count').find('span').text(num_adults);
+			$(this).find('.num_children').val(0).siblings('.occupancy_count').find('span').text(0);
+			$(this).find('.children_ages > div').remove();
+		} else {
+			$(element).remove();
+		}
+	});
+}


### PR DESCRIPTION
- If a user is coming to a room type detail page from its hotel page (or search results page), do not set default occupancy, or disaplay 'Select Occupancy'.
- If a user is coming to a room type detail page directly, set Base Adult occupancy of the room type.