### PR TITLE
Fixed: Datepicker field does not auto hide in admin refund request controller 

### DIFF
--- a/modules/hotelreservationsystem/views/js/admin/wk_refund_request.js
+++ b/modules/hotelreservationsystem/views/js/admin/wk_refund_request.js
@@ -121,7 +121,7 @@ $(document).ready(function() {
             $('#generateCreditSlip, #generateDiscount').prop('checked', false);
 			$(this).prop('checked', true);
 		}
-        $('#generateCreditSlip').change();
+        $('#generateCreditSlip, #generateDiscount').change();
 	});
 
     $(document).on('keyup', '#order_return_form .table input[name^="refund_amounts"]', function() {


### PR DESCRIPTION
datepicker field does not hide in the admin refund request controller when the create credit slip option is selected after selecting the voucher option