### PR TITLE
Fixed: Translation issues in the front office

### DIFF
--- a/js/daterangepicker/qlodaterangepicker.js
+++ b/js/daterangepicker/qlodaterangepicker.js
@@ -20,6 +20,10 @@
 (function($) {
 
     var dateRangePickerOrg = $.fn.dateRangePicker;
+    Object.assign($.dateRangePickerLanguages, {
+        zh: $.dateRangePickerLanguages.cn,
+        tw: $.dateRangePickerLanguages.tc
+    });
     $.fn.dateRangePicker = function(opt) {
         if(typeof opt === "object") {
             let container = $(this).parent();

--- a/modules/wkroomsearchblock/views/templates/hook/searchForm.tpl
+++ b/modules/wkroomsearchblock/views/templates/hook/searchForm.tpl
@@ -85,7 +85,7 @@
                         <div class="dropdown">
                             <button class="form-control input-occupancy header-rmsearch-input {if isset($error) && $error == 1}error_border{/if}" type="button" data-toggle="dropdown" id="guest_occupancy">
                                 <span class="pull-left">{if (isset($search_data['occupancy_adults']) && $search_data['occupancy_adults'])}{$search_data['occupancy_adults']} {if $search_data['occupancy_adults'] > 1}{l s='Adults' mod='wkroomsearchblock'}{else}{l s='Adult' mod='wkroomsearchblock'}{/if}, {if isset($search_data['occupancy_children']) && $search_data['occupancy_children']}{$search_data['occupancy_children']} {if $search_data['occupancy_children'] > 1}
-                                {l s='Children' mod='wkroomsearchblock'}{else}{l s='Child' mod='wkroomsearchblock'}{/if}, {/if}{$search_data['occupancies']|count} {if $search_data['occupancies']|count > 1}{l s='Rooms' mod='wkroomsearchblock'}{else}{l s='Room'}{/if}{else}{l s='1 Adult, 1 Room' mod='wkroomsearchblock'}{/if}</span>
+                                {l s='Children' mod='wkroomsearchblock'}{else}{l s='Child' mod='wkroomsearchblock'}{/if}, {/if}{$search_data['occupancies']|count} {if $search_data['occupancies']|count > 1}{l s='Rooms' mod='wkroomsearchblock'}{else}{l s='Room' mod='wkroomsearchblock'}{/if}{else}{l s='1 Adult, 1 Room' mod='wkroomsearchblock'}{/if}</span>
                             </button>
                             <div id="search_occupancy_wrapper" class="dropdown-menu">
                                 <div id="occupancy_inner_wrapper">

--- a/themes/hotel-reservation-theme/modules/blockuserinfo/nav.tpl
+++ b/themes/hotel-reservation-theme/modules/blockuserinfo/nav.tpl
@@ -31,8 +31,8 @@
                     </button>
                     <ul class="dropdown-menu" aria-labelledby="user_info_acc">
                         <li><a href="{$link->getPageLink('my-account', true)|escape:'html'}" title="{l s='View my customer account' mod='blockuserinfo'}">{l s='Accounts'  mod='blockuserinfo'}</a></li>
-                        <li><a href="{$link->getPageLink('history', true)|escape:'html'}" title="{l s='View my orders' mod='blockuserinfo'}">{l s='Orders'}</a></li>
-                        <li><a href="{$link->getPageLink('index', true, NULL, "mylogout")|escape:'html'}"  title="{l s='Log me out' mod='blockuserinfo'}">{l s='Logout'}</a></li>
+                        <li><a href="{$link->getPageLink('history', true)|escape:'html'}" title="{l s='View my orders' mod='blockuserinfo'}">{l s='Orders' mod='blockuserinfo'}</a></li>
+                        <li><a href="{$link->getPageLink('index', true, NULL, "mylogout")|escape:'html'}"  title="{l s='Log me out' mod='blockuserinfo'}">{l s='Logout' mod='blockuserinfo'}</a></li>
                         {block name='displayUserNavigationList'}
                             {hook h='displayUserNavigationList'}
                         {/block}


### PR DESCRIPTION
Fixes:
- Unable to translate the text "1 Adult, 1 Room" in the Room Search Panels in the front office.
- Unable to translate the text "Orders" and "logout" in the nav in the front office.
-  Added alias for tw and zh languages for the daterangepicker for the front office.