### PR TITLE
Fix(ioc): replace deprecated ReflectionParameter::getClass() with get…

### DIFF
--- a/Core/Foundation/IoC/Core_Foundation_IoC_Container.php
+++ b/Core/Foundation/IoC/Core_Foundation_IoC_Container.php
@@ -123,7 +123,7 @@ class Core_Foundation_IoC_Container
                     } else {
                         throw new Core_Foundation_IoC_Exception(sprintf('Cannot build a `%s`.', $className));
                     }
-				}
+                }
             }
         }
 

--- a/Core/Foundation/IoC/Core_Foundation_IoC_Container.php
+++ b/Core/Foundation/IoC/Core_Foundation_IoC_Container.php
@@ -105,14 +105,25 @@ class Core_Foundation_IoC_Container
 
         if ($classConstructor) {
             foreach ($classConstructor->getParameters() as $param) {
-                $paramClass = $param->getClass();
-                if ($paramClass) {
-                    $args[] = $this->doMake($param->getClass()->getName(), $alreadySeen);
-                } elseif ($param->isDefaultValueAvailable()) {
-                    $args[] = $param->getDefaultValue();
-                } else {
-                    throw new Core_Foundation_IoC_Exception(sprintf('Cannot build a `%s`.', $className));
-                }
+                if (method_exists($param, 'getType')) {
+                    $type = $param->getType();
+                    if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
+                        $args[] = $this->doMake($type->getName(), $alreadySeen);
+                    } elseif ($param->isDefaultValueAvailable()) {
+                        $args[] = $param->getDefaultValue();
+                    } else {
+                        throw new Core_Foundation_IoC_Exception(sprintf('Cannot build a `%s`.', $className));
+                    }
+				} else {
+                    $paramClass = $param->getClass();
+                    if ($paramClass) {
+                        $args[] = $this->doMake($paramClass->getName(), $alreadySeen);
+                    } elseif ($param->isDefaultValueAvailable()) {
+                        $args[] = $param->getDefaultValue();
+                    } else {
+                        throw new Core_Foundation_IoC_Exception(sprintf('Cannot build a `%s`.', $className));
+                    }
+				}
             }
         }
 


### PR DESCRIPTION
…Type()

PHP 8 deprecates ReflectionParameter::getClass(). Replaced with getType() and proper ReflectionNamedType check to ensure compatibility with modern PHP versions.

Fixes PHP deprecation warning and ensures future-proof reflection handling.