### PR TITLE
Fixed: show undefined key warning when exporting CSV from Admin Stats (Customer Account tab) in the back-office.

### DIFF
--- a/modules/statsregistrations/statsregistrations.php
+++ b/modules/statsregistrations/statsregistrations.php
@@ -184,7 +184,11 @@ class StatsRegistrations extends ModuleGraph
     {
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($this->query.$this->getDate());
         foreach ($result as $row) {
-            $this->_values[(int)Tools::substr($row['date_add'], 0, 4)]++;
+            $days = (int)Tools::substr($row['date_add'], 0, 4);
+            if (!isset($this->_values[$days])) {
+                $this->_values[$days] = 0;
+            }
+            $this->_values[$days]++;
         }
     }
 
@@ -204,7 +208,11 @@ class StatsRegistrations extends ModuleGraph
     {
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($this->query.$this->getDate());
         foreach ($result as $row) {
-            $this->_values[(int)Tools::substr($row['date_add'], 8, 2)]++;
+            $days = (int)Tools::substr($row['date_add'], 8, 2);
+            if (!isset($this->_values[$days])) {
+                $this->_values[$days] = 0;
+            }
+            $this->_values[$days]++;
         }
     }
 
@@ -212,7 +220,11 @@ class StatsRegistrations extends ModuleGraph
     {
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($this->query.$this->getDate());
         foreach ($result as $row) {
-            $this->_values[(int)Tools::substr($row['date_add'], 11, 2)]++;
+            $hour = (int)Tools::substr($row['date_add'], 11, 2);
+            if (!isset($this->_values[$hour])) {
+                $this->_values[$hour] = 0;
+            }
+            $this->_values[$hour]++;
         }
     }
 }

--- a/modules/statsregistrations/statsregistrations.php
+++ b/modules/statsregistrations/statsregistrations.php
@@ -184,11 +184,11 @@ class StatsRegistrations extends ModuleGraph
     {
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($this->query.$this->getDate());
         foreach ($result as $row) {
-            $days = (int)Tools::substr($row['date_add'], 0, 4);
-            if (!isset($this->_values[$days])) {
-                $this->_values[$days] = 0;
+            $year = (int)Tools::substr($row['date_add'], 0, 4);
+            if (!isset($this->_values[$year])) {
+                $this->_values[$year] = 0;
             }
-            $this->_values[$days]++;
+            $this->_values[$year]++;
         }
     }
 


### PR DESCRIPTION
1. Undefined key notices in the admin stats (customer account tab )  while trying to export the data using the CSV export.