### PR TITLE
Fixed: display incorrect validation alert when issuing a full refund via PayPal after a partial refund in the back-office.

### DIFF
--- a/modules/qlopaypalcommerce/controllers/admin/AdminPaypalCommerceTransactionController.php
+++ b/modules/qlopaypalcommerce/controllers/admin/AdminPaypalCommerceTransactionController.php
@@ -156,7 +156,7 @@ class AdminPaypalCommerceTransactionController extends ModuleAdminController
                     $smartyVars['ppstatusDetailMsg'] = $objPPOrder->ppStatusDetail[$response['data']['purchase_units'][0]['payments']['captures'][0]['status_details']['reason']];
                 }
             }
-
+            $smartyVars['refund_url'] = $this->context->link->getAdminLink('AdminPaypalCommerceTransaction',Tools::getAdminTokenLite('AdminPaypalCommerceTransaction')).'&viewwk_paypal_commerce_order&id_paypal_commerce_order=' . (int)$idTrans;
             $smartyVars['transaction_data'] = $transactionData;
             $smartyVars['refund_data'] = $refundData;
             $smartyVars['refunded_amount'] = $totalRefundedFormatted;

--- a/modules/qlopaypalcommerce/controllers/admin/AdminPaypalCommerceTransactionController.php
+++ b/modules/qlopaypalcommerce/controllers/admin/AdminPaypalCommerceTransactionController.php
@@ -156,7 +156,7 @@ class AdminPaypalCommerceTransactionController extends ModuleAdminController
                     $smartyVars['ppstatusDetailMsg'] = $objPPOrder->ppStatusDetail[$response['data']['purchase_units'][0]['payments']['captures'][0]['status_details']['reason']];
                 }
             }
-            $smartyVars['refund_url'] = $this->context->link->getAdminLink('AdminPaypalCommerceTransaction',Tools::getAdminTokenLite('AdminPaypalCommerceTransaction')).'&viewwk_paypal_commerce_order&id_paypal_commerce_order=' . (int)$idTrans;
+            $smartyVars['transaction_url'] = $this->context->link->getAdminLink('AdminPaypalCommerceTransaction',Tools::getAdminTokenLite('AdminPaypalCommerceTransaction')).'&viewwk_paypal_commerce_order&id_paypal_commerce_order=' . (int)$idTrans;
             $smartyVars['transaction_data'] = $transactionData;
             $smartyVars['refund_data'] = $refundData;
             $smartyVars['refunded_amount'] = $totalRefundedFormatted;

--- a/modules/qlopaypalcommerce/views/templates/admin/paypal_commerce_transaction/helpers/view/view.tpl
+++ b/modules/qlopaypalcommerce/views/templates/admin/paypal_commerce_transaction/helpers/view/view.tpl
@@ -107,7 +107,7 @@
 {if $transaction_data and $transaction_data.pp_payment_status == 'COMPLETED'}
     {* show refund form only if there is any remaing amount for refund *}
     {if $remaining_refund > 0}
-        <form action="{$refund_url|escape:'html':'UTF-8'}" method="post" class="form-horizontal" id="refund_form">
+        <form action="{$transaction_url|escape:'html':'UTF-8'}" method="post" class="form-horizontal" id="refund_form">
             <div class="panel col-lg-12">
                 <div class="panel-heading">
                     <i class="icon-reply"></i>

--- a/modules/qlopaypalcommerce/views/templates/admin/paypal_commerce_transaction/helpers/view/view.tpl
+++ b/modules/qlopaypalcommerce/views/templates/admin/paypal_commerce_transaction/helpers/view/view.tpl
@@ -107,7 +107,7 @@
 {if $transaction_data and $transaction_data.pp_payment_status == 'COMPLETED'}
     {* show refund form only if there is any remaing amount for refund *}
     {if $remaining_refund > 0}
-        <form action="" method="post" class="form-horizontal" id="refund_form">
+        <form action="{$refund_url|escape:'html':'UTF-8'}" method="post" class="form-horizontal" id="refund_form">
             <div class="panel col-lg-12">
                 <div class="panel-heading">
                     <i class="icon-reply"></i>


### PR DESCRIPTION
When issuing a full refund after a partial PayPal refund, the transaction details in the back office no longer display two separate validation entries.