### PR TITLE
Fixed: show undefined variable warning in admin stats (extra services overview tab) during csv export in the back-office.

### DIFF
--- a/classes/module/ModuleGrid.php
+++ b/classes/module/ModuleGrid.php
@@ -159,12 +159,13 @@ abstract class ModuleGridCore extends Module
         $this->setLang($context->language->id);
         $this->setEmployee($context->employee->id);
 
+        $layers = isset($datas['layers']) ?  $datas['layers'] : 1;
+
         if (isset($datas['option'])) {
             $this->setOption($datas['option'], $layers);
         }
         $this->getData();
 
-        $layers = isset($datas['layers']) ?  $datas['layers'] : 1;
 
         if (count($datas['columns'])) {
             foreach ($datas['columns'] as $column) {


### PR DESCRIPTION
Getting Warning: Undefined variable in the admin stats (Extra services overview tab ) while trying to export the data using the CSV export.
https://webkul.chatwhizz.com/share/screenshot/693a58fa101c3706b2823531