### PR TITLE
Fixed: Service product quantity not showing on the order details page in the back office

### DIFF
--- a/admin/themes/default/template/controllers/orders/modals/_extra_services_service_products_tab_content.tpl
+++ b/admin/themes/default/template/controllers/orders/modals/_extra_services_service_products_tab_content.tpl
@@ -279,9 +279,7 @@
 						</td>
                         <td class="text-center">
                             {if isset($service['allow_multiple_quantity']) && $service['allow_multiple_quantity']}
-                                <div class="qty_container">
-                                    <input type="number" class="form-control qty" min="1"  value="{$service['quantity']|escape:'html':'UTF-8'}" disabled="disabled"/>
-                                </div>
+                                {$service['quantity']}
                             {else}
                                 {l s='--'}
                             {/if}

--- a/admin/themes/default/template/controllers/orders/modals/_extra_services_service_products_tab_content.tpl
+++ b/admin/themes/default/template/controllers/orders/modals/_extra_services_service_products_tab_content.tpl
@@ -256,6 +256,7 @@
 					<th>{l s='ID'}</th>
 					<th>{l s='Name'}</th>
 					<th></th>
+                    <th class="fixed-width-sm text-center">{l s='Quantity'}</th>
 					<th>{l s='Unit Price (tax excl.)'}</th>
 					<th>{l s='Total Price (tax excl.)'}</th>
 					<th>{l s='Total Price (tax incl.)'}</th>
@@ -276,6 +277,15 @@
 								<span class="badge badge-info label">{l s='Auto added'}</span>
 							{/if}
 						</td>
+                        <td class="text-center">
+                            {if isset($service['allow_multiple_quantity']) && $service['allow_multiple_quantity']}
+                                <div class="qty_container">
+                                    <input type="number" class="form-control qty" min="1"  value="{$service['quantity']|escape:'html':'UTF-8'}" disabled="disabled"/>
+                                </div>
+                            {else}
+                                {l s='--'}
+                            {/if}
+                        </td>
 						<td>
 							{displayPrice price=$service['unit_price_tax_excl'] currency=$orderCurrency}
 							{if $service['price_calculation_method'] == Product::PRICE_CALCULATION_METHOD_PER_DAY}


### PR DESCRIPTION
On the Order Detail page, the quantity for service products is not being displayed. This makes it unclear how many units of a service have been ordered, especially in cases where more than one unit of the same service is booked.