### PR TITLE
Fixed: show incorrect theme compatibility version when trying to export the theme in the back-office.

### DIFF
--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -1358,8 +1358,8 @@ class AdminThemesControllerCore extends AdminController
         $fields_value['theme_name'] = $theme->name;
         $fields_value['theme_directory'] = $theme->directory;
         $fields_value['theme_version'] = '1.0';
-        $fields_value['compa_from'] = _PS_VERSION_;
-        $fields_value['compa_to'] = _PS_VERSION_;
+        $fields_value['compa_from'] = _QLOAPPS_VERSION_;
+        $fields_value['compa_to'] = _QLOAPPS_VERSION_;
         $fields_value['id_theme_export'] = Tools::getValue('id_theme_export');
         $fields_value['documentationName'] = $this->l('documentation');
 


### PR DESCRIPTION
Incorrect use of _PS_VERSION_ in AdminThemeController. If we create any new theme for version >= 1.7.0, the compatibility shown is incorrect.