### PR TITLE
Fixed:Selected service price not included in total when no service mapping exists in  back-office .

### DIFF
--- a/admin/themes/default/template/controllers/orders/_current_cart_details_data.tpl
+++ b/admin/themes/default/template/controllers/orders/_current_cart_details_data.tpl
@@ -130,7 +130,7 @@
 								{* <td class="cart_line_total_rooms_price" id="cart_detail_data_price_{$data.id|escape:'html':'UTF-8'}">
 									{displayPrice price=$data.amt_with_qty}</td> *}
 								<td class="cart_line_total_price">
-									{if (isset($data.extra_demands) && $data.extra_demands) || (isset($data.additional_service) && $data.additional_service)}
+									{if (isset($data.extra_demands) && $data.extra_demands) || (isset($data.additional_service) && $data.additional_service) || (isset($data.selected_services) && $data.selected_services)}
 										{displayPrice price=($data.amt_with_qty + $data.additional_services_auto_add_price + $data.demand_price +  $data.additional_service_price)|escape:'html':'UTF-8'}
 									{else}
 										{displayPrice price=$data.amt_with_qty|escape:'html':'UTF-8'}


### PR DESCRIPTION
When a room type had no service mapping configured, the price of selected services was not being added to the total booking price. This caused incorrect total calculations.